### PR TITLE
change browse-url to use gh view

### DIFF
--- a/consult-gh-embark.el
+++ b/consult-gh-embark.el
@@ -19,11 +19,11 @@
 
 (defun consult-gh-embark-open-in-browser (cand)
   "Open the link in browser"
-(let* ((repo (get-text-property 0 :repo cand))
-      (issue (or (get-text-property 0 :issue cand) nil)))
-      (if issue
-          (browse-url (concat "https://github.com/" (substring-no-properties repo) "\/issues\/" (substring-no-properties issue)))
-        (browse-url (concat "https://github.com/" (substring-no-properties repo))))))
+  (let* ((repo (get-text-property 0 :repo cand))
+         (issue (or (get-text-property 0 :issue cand) nil)))
+    (if issue
+        (consult-gh--call-process "issue" "view" "--web" "--repo" (substring-no-properties repo) (substring-no-properties issue))
+      (consult-gh--call-process "repo" "view" "--web" (substring repo)))))
 
 (defun consult-gh-embark-get-ssh-link (cand)
   "Copy the ssh based link of the repo to `kill-ring'."
@@ -44,13 +44,13 @@
   "List other repos by the same user/organization as the repo at point."
   (let* ((repo  (get-text-property 0 :repo cand))
          (user (car (split-string repo "\/"))))
-  (consult-gh-orgs `(,user))))
+    (consult-gh-orgs `(,user))))
 
 (defun consult-gh-embark-view-issues-of-repo (cand)
   "View issues of the repo at point."
   (let* ((repo (get-text-property 0 :repo cand))
          )
-  (consult-gh-issue-list `(,repo))))
+    (consult-gh-issue-list `(,repo))))
 
 (defun consult-gh-embark-clone-repo (cand)
   "Clone the repo at point."

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -245,7 +245,7 @@
 (defun consult-gh--repo-browse-url-action ()
 "Default action to run on selected itesm in `consult-gh'."
 (lambda (cand)
-  (browse-url (concat "https://github.com/" (substring cand)))
+  (consult-gh--call-process "repo" "view" "--web" (substring-no-properties cand))
 ))
 
 (defun consult-gh--repo-view (repo &optional buffer)
@@ -395,7 +395,8 @@
 (defun consult-gh--browse-issue-url-action ()
 "Default action to run on selected itesm in `consult-gh'."
 (lambda (cand)
-  (browse-url (concat "https://github.com/" (substring (get-text-property 0 :repo cand)) "\/issues\/" (substring (get-text-property 0 :issue cand))))))
+  (consult-gh--call-process "issue" "view" "--repo" (substring-no-properties (get-text-property 0 :repo cand))  "--web" (substring-no-properties (get-text-property 0 :issue cand)))
+  ))
 
 (defun consult-gh--issue-view (repo issue &optional buffer)
   "Default action to run on selected item in `consult-gh'."

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -288,7 +288,7 @@
 (defun consult-gh--repo-browse-url-action ()
 "Default action to run on selected itesm in `consult-gh'."
 (lambda (cand)
-  (browse-url (concat "https://github.com/" (substring cand)))
+  (consult-gh--call-process "repo" "view" "--web" (substring-no-properties cand))
 ))
 #+end_src
 ***** view repo
@@ -472,7 +472,8 @@
 (defun consult-gh--browse-issue-url-action ()
 "Default action to run on selected itesm in `consult-gh'."
 (lambda (cand)
-  (browse-url (concat "https://github.com/" (substring (get-text-property 0 :repo cand)) "\/issues\/" (substring (get-text-property 0 :issue cand))))))
+  (consult-gh--call-process "issue" "view" "--repo" (substring-no-properties (get-text-property 0 :repo cand))  "--web" (substring-no-properties (get-text-property 0 :issue cand)))
+  ))
 #+end_src
 ***** view issue
 #+begin_src emacs-lisp
@@ -727,11 +728,11 @@
 
 (defun consult-gh-embark-open-in-browser (cand)
   "Open the link in browser"
-(let* ((repo (get-text-property 0 :repo cand))
-      (issue (or (get-text-property 0 :issue cand) nil)))
-      (if issue
-          (browse-url (concat "https://github.com/" (substring-no-properties repo) "\/issues\/" (substring-no-properties issue)))
-        (browse-url (concat "https://github.com/" (substring-no-properties repo))))))
+  (let* ((repo (get-text-property 0 :repo cand))
+         (issue (or (get-text-property 0 :issue cand) nil)))
+    (if issue
+        (consult-gh--call-process "issue" "view" "--web" "--repo" (substring-no-properties repo) (substring-no-properties issue))
+      (consult-gh--call-process "repo" "view" "--web" (substring repo)))))
 
 (defun consult-gh-embark-get-ssh-link (cand)
   "Copy the ssh based link of the repo to `kill-ring'."
@@ -752,13 +753,13 @@
   "List other repos by the same user/organization as the repo at point."
   (let* ((repo  (get-text-property 0 :repo cand))
          (user (car (split-string repo "\/"))))
-  (consult-gh-orgs `(,user))))
+    (consult-gh-orgs `(,user))))
 
 (defun consult-gh-embark-view-issues-of-repo (cand)
   "View issues of the repo at point."
   (let* ((repo (get-text-property 0 :repo cand))
          )
-  (consult-gh-issue-list `(,repo))))
+    (consult-gh-issue-list `(,repo))))
 
 (defun consult-gh-embark-clone-repo (cand)
   "Clone the repo at point."


### PR DESCRIPTION
Changed the **browse-url functions** to use `gh repo view` and `gh issue view` instead. Therefore Github Enterprise hosts will use the right host.

- add embark action for open in browser
- change browse-url functions
