### PR TITLE
Better Handling of LArge Files

### DIFF
--- a/README.org
+++ b/README.org
@@ -200,7 +200,7 @@ Here is a good customization for great performance as well as functionality:
   (consult-gh-issue-action #'consult-gh--issue-view-action)
   (consult-gh-repo-action #'consult-gh--repo-browse-files-action)
   (consult-gh-file-action #'consult-gh--files-view-action)
-  (consult-gh-large-file-warning-threshold 5000000)
+  (consult-gh-large-file-warning-threshold 2500000)
   :config
   ;;add your main GitHub account (replace "armindarvish" with your user or org)
   (add-to-list 'consult-gh-default-orgs-list "armindarvish")

--- a/README.org
+++ b/README.org
@@ -115,6 +115,9 @@ This is the limit passed to =gh= as =--limit= argument to =gh repo list= or =gh 
 **** =consult-gh--issue-maxnum=
 This is the limit passed to =gh= as =--limit= argument to =gh issue list= or =gh search issues= commands and defines the number of issues shown when listing or searching for issues. By default, it is set to 30 following the default values of =gh= itself, but it can be customized by the user to see more or fewer results.
 
+**** =consult-gh-large-file-warning-threshold=
+This is the maximum file size, above which =consult-gh= requests a confirmation for previewing, opening or saving the file. Default value is set by emacs built-in =large-file-warning-threshold= variable, but since =consult-gh= is downloading files from the internet, you may want to set this to a smaller value than =large-file-warning-threshold=  depending on your network performance.
+
 **** =consult-gh--issues-state-to-show=
 The state of issues shown when listing or searching for issues. This is the string passed as =--state= argument to =gh search issues= or =gh issue list= and can accept =open=, =closed= or =all= for open, closed or all issues, respectively.
 
@@ -197,6 +200,7 @@ Here is a good customization for great performance as well as functionality:
   (consult-gh-issue-action #'consult-gh--issue-view-action)
   (consult-gh-repo-action #'consult-gh--repo-browse-files-action)
   (consult-gh-file-action #'consult-gh--files-view-action)
+  (consult-gh-large-file-warning-threshold 5000000)
   :config
   ;;add your main GitHub account (replace "armindarvish" with your user or org)
   (add-to-list 'consult-gh-default-orgs-list "armindarvish")

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -76,6 +76,11 @@
   :group 'consult-gh
   :type '(choice "open" "closed" "all"))
 
+(defcustom consult-gh-large-file-warning-threshold large-file-warning-threshold
+  "Maximum size of file above which `consult-gh' requests a confirmation for previewing, opening or saving the file. Default value is set by `large-file-warning-threshold'."
+  :group 'consult-gh
+  :type '(choice integer (const :tag "Never request confirmation" nil)))
+
 (defcustom consult-gh-preview-buffer-mode 'markdown-mode
   "Major mode to show README of repositories in preview. choices are 'markdown-mode or 'org-mode"
   :group 'consult-gh
@@ -506,7 +511,6 @@ Output is the buffer visiting the file."
          (suffix (concat "." (file-name-extension path)))
          (temp-file (expand-file-name path tempdir))
          (text (consult-gh--files-get-content url)))
-
          (make-directory (file-name-directory temp-file) t)
          (with-temp-file temp-file
            (insert text)
@@ -525,8 +529,14 @@ Output is the buffer visiting the file."
     (let* ((repo (get-text-property 0 ':repo cand))
            (path (get-text-property 0 ':path cand))
            (url (get-text-property 0 ':url cand))
-           (file-p (or (file-name-extension path) (get-text-property 0 ':size cand))))
-      (if file-p
+           (file-p (or (file-name-extension path) (get-text-property 0 ':size cand)))
+           (file-size (and file-p (get-text-property 0 ':size cand)))
+           (confirm t))
+      (when (>= file-size consult-gh-large-file-warning-threshold)
+        (if (yes-or-no-p (format "File is %s Bytes. Do you really want to load it?" file-size))
+         (setq confirm t)
+       (setq confirm nil)))
+      (if (and file-p confirm)
           (consult-gh--files-view repo path url)
       ))))
 
@@ -541,15 +551,21 @@ Output is the buffer visiting the file."
            (url (get-text-property 0 ':url cand))
            (file-p (or (file-name-extension path) (get-text-property 0 ':size cand)))
            (filename (and file-p (file-name-nondirectory path)))
-           (buffer (and file-p (consult-gh--files-view repo path url t))))
-    (if file-p
+           (file-size (and file-p (get-text-property 0 ':size cand)))
+           (confirm t)
+           (targetpath (if consult-gh-ask-for-path-before-save
+                           (file-truename (read-file-name "Save As: " consult-gh-default-save-directory filename nil filename))
+                         consult-gh-default-save-directory)))
+   (when (>= file-size consult-gh-large-file-warning-threshold)
+     (if (yes-or-no-p (format "File is %s Bytes. Do you really want to load it?" file-size))
+         (setq confirm t)
+       (setq confirm nil)))
+(let ((buffer (and file-p (consult-gh--files-view repo path url t))))
+      (if (and file-p confirm)
     (save-mark-and-excursion
       (save-restriction
         (with-current-buffer buffer
-          (if consult-gh-ask-for-path-before-save
-          (write-file (read-file-name "Save As: " consult-gh-default-save-directory filename nil filename) t)
-          (write-file consult-gh-default-save-directory t)
-          )
+          (write-file targetpath t))
         )))))))
 
 #+end_src
@@ -578,15 +594,19 @@ For more info on state functions refer to `consult''s manual, and particularly `
                     (branch (get-text-property 0 ':branch cand))
                     (url (get-text-property 0 ':url cand))
                     (file-p (or (file-name-extension path) (get-text-property 0 ':size cand)))
+                    (file-size (and file-p (get-text-property 0 ':size cand)))
+                    (confirm (if (and file-p (>= file-size consult-gh-large-file-warning-threshold))
+                                 (yes-or-no-p (format "File is %s Bytes. Do you really want to load it?" file-size))
+                               t))
                     (tempdir (expand-file-name (concat repo "/" branch) consult-gh-tempdir))
                     (prefix (concat (file-name-sans-extension  (file-name-nondirectory path))))
                     (suffix (concat "." (file-name-extension path)))
                     (temp-file (expand-file-name path tempdir))
-                    (_ (and file-p (make-directory (file-name-directory temp-file) t)))
-                    (text (and file-p (consult-gh--files-get-content url)))
-                    (_ (and file-p (with-temp-file temp-file (insert text) (set-buffer-file-coding-system 'raw-text)
+                    (_ (and file-p confirm (make-directory (file-name-directory temp-file) t)))
+                    (text (and file-p confirm (consult-gh--files-get-content url)))
+                    (_ (and file-p confirm (with-temp-file temp-file (insert text) (set-buffer-file-coding-system 'raw-text)
                                                    )))
-                    (buffer (or (and file-p (with-temp-buffer (find-file-noselect temp-file t))) nil)))
+                    (buffer (or (and file-p confirm (with-temp-buffer (find-file-noselect temp-file t))) nil)))
                (add-to-list 'consult-gh--preview-buffers-list buffer)
                (funcall preview action
                         (and


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When the automatic preview is on (`consult-gh-preview-key` is set to "any") consult-gh loads any files (even really large files) which is slow, it would be good to ask the user to confirm before doing that. Same flow should be used for opening files in Emacs buffers or for saving files locally.

**Describe the solution you'd like**
A customization variable to define the file size threshold, above which, a confirmation is needed before downloading the file.
