### PR TITLE
Fix symbolp error caused by missing quotes

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -951,18 +951,18 @@ For more info on consult dources see `consult''s manual for example documentaion
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history nil t)) '(""))
+            action candidates string predicate))) nil nil repo-from-current-dir 'consult-gh--repos-history nil t)) '(""))
          (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '(""))))
       ('nil
        (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '("")))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '("")))
       ('t
        (if repo-from-current-dir
            (list repo-from-current-dir)
@@ -970,7 +970,7 @@ For more info on consult dources see `consult''s manual for example documentaion
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '("")))))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '("")))))))
 
 (defun consult-gh--read-branch (repo)
   (pcase consult-gh-default-branch-to-load


### PR DESCRIPTION
Hi. Whenever I use an interactive command that calls `consult-gh--read-repo-name`, I get an error like:
``` text
apply: Wrong type argument: symbolp, "LemonBreezes/.doom.d-old�����"
```
Because the `consult-gh--repos-history` variable is not quoted in the `complete-with-action` call. So this PR addresses that error.
