### PR TITLE
Improve handling of history variables and local repos

### DIFF
--- a/README.org
+++ b/README.org
@@ -126,11 +126,11 @@ This is the maximum file size, above which =consult-gh= requests a confirmation 
 
 **** =consult-gh-prioritize-local-folder=
 
-This varibale defines whther =gh= uses the git repo in the local folder to select/guess the repository for commands like =consult-gh-find-file= and =consult-gh-issue-list=, etc. Note that everything is still retrieved from the remote (for example =consult-gh-find-file=  would fetch the contents of the repo from remote and not from the local folder) but the local repo name is used instead of querying the user.
+This varibale defines whther =gh= uses the git repo in the local folder to select/guess the repository for commands like =consult-gh-find-file= and =consult-gh-issue-list=, etc. Note that everything is still retrieved from the remote (for example =consult-gh-find-file= would fetch the contents of the repo from remote and not from the local folder) but the local repo name is used instead of querying the user.
 You can set this varibale to ='suggest=, =t=, or =nil=
-- 'suggest simply adds the local repo name as default input in the minibuffer so you don't have to type it out.
+- 'suggest simply adds the local repo name as initial input in the minibuffer so you don't have to type it out.
 - t would skip the query and uses the local repo name, if any, otherwise it falls back to querying the user.
-- nil would ignore the local repo name in the default-directory.
+- nil would not suggest the local repo name as initial-input but instead uses it as default value. That means the local repo is added to the end of history list (accessible by default keybinding =M-n=).
 
 **** =consult-gh--issues-state-to-show=
 The state of issues shown when listing or searching for issues. This is the string passed as =--state= argument to =gh search issues= or =gh issue list= and can accept =open=, =closed= or =all= for open, closed or all issues, respectively.

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -951,24 +951,24 @@ For more info on consult dources see `consult''s manual for example documentaion
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history repo-from-current-dir t)) '(""))
+            action candidates string predicate))) nil nil repo-from-current-dir 'consult-gh--repos-history repo-from-current-dir t)) '(""))
          (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '(""))))
       ('nil
        (if repo-from-current-dir
            (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history repo-from-current-dir t)) '(""))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history repo-from-current-dir t)) '(""))
        (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '(""))))
       ('t
        (if repo-from-current-dir
            (list repo-from-current-dir)
@@ -976,7 +976,7 @@ For more info on consult dources see `consult''s manual for example documentaion
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '("")))))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '("")))))))
 
 (defun consult-gh--read-branch (repo)
   (pcase consult-gh-default-branch-to-load

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -963,7 +963,7 @@ For more info on consult dources see `consult''s manual for example documentaion
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history repo-from-current-dir t)) '(""))
+            action candidates string predicate))) nil nil nil consult-gh--repos-history repo-from-current-dir t)) '(""))
        (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -1157,7 +1157,7 @@ This section defines functions that are used to get input from user without cons
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history repo-from-current-dir t)) '(""))
+            action candidates string predicate))) nil nil nil consult-gh--repos-history repo-from-current-dir t)) '(""))
        (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -1145,24 +1145,24 @@ This section defines functions that are used to get input from user without cons
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history repo-from-current-dir t)) '(""))
+            action candidates string predicate))) nil nil repo-from-current-dir 'consult-gh--repos-history repo-from-current-dir t)) '(""))
          (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '(""))))
       ('nil
        (if repo-from-current-dir
            (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history repo-from-current-dir t)) '(""))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history repo-from-current-dir t)) '(""))
        (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '(""))))
       ('t
        (if repo-from-current-dir
            (list repo-from-current-dir)
@@ -1170,7 +1170,7 @@ This section defines functions that are used to get input from user without cons
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '("")))))))
+            action candidates string predicate))) nil nil nil 'consult-gh--repos-history nil t)) '("")))))))
 
 #+end_src
 **** consult-gh--read-branch

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -81,10 +81,10 @@
   :type '(choice integer (const :tag "Never request confirmation" nil)))
 
 (defcustom consult-gh-prioritize-local-folder nil
-"This varibale defines how `gh` selects repositories and it can either be the symbol 'suggest or a a boolean.
-If it is set to 'suggest, consult-gh uses the git repository from the local folder (a.k.a. `default-directory'), if any, as the initial-input value for commands such as `consult-gh-issue-list' or `consult-gh-find-file'.
-If it is set to t, consult-gh uses the git repository from the local folder (a.k.a. `default-directory'), if any, instead of querying the user and if there is no GitHub repository in the current folder falls back on querying the user for those commands.
-If it is set to nil, consult-gh ignores the GitHub repository from the local folder (a.k.a. `default-directory') and always queris the user to chose a repository for those commands."
+"This varibale defines how `gh` selects repositories and it can either be the symbol 'suggest or a boolean.
+If it is set to 'suggest, consult-gh uses the git repository from the local folder (a.k.a. `default-directory'), if any, as the initial-input value for commands such as `consult-gh-issue-list' or `consult-gh-find-file'. The user can still change the entry but this allows quickly selecting the current repo by just hitting return saving a few keystrokes.
+If it is set to t, consult-gh uses the git repository from the local folder (a.k.a. `default-directory'), if any, instead of querying the user. If there is no GitHub repository in the current folder, it falls back on querying the user.
+If it is set to nil, consult-gh always queries the user for name of repo but instead of suggesting the GitHub repository from the local folder (a.k.a. `default-directory') as initial-input, it adds that to  to the end of history (default keybinding `M-n`)."
 :group 'consult-gh
 :type '(choice boolean (symbol 'suggest)))
 
@@ -1145,18 +1145,24 @@ This section defines functions that are used to get input from user without cons
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history nil t)) '(""))
+            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history repo-from-current-dir t)) '(""))
          (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
             action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
       ('nil
+       (if repo-from-current-dir
+           (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
+         (if (eq action 'metadata)
+             '(metadata (category . consult-gh-repos))
+           (complete-with-action
+            action candidates string predicate))) nil nil repo-from-current-dir consult-gh--repos-history repo-from-current-dir t)) '(""))
        (or (delete-dups (completing-read-multiple "Repo(s) in OWNER/REPO format (e.g. armindarvish/consult-gh): " (lambda (string predicate action)
          (if (eq action 'metadata)
              '(metadata (category . consult-gh-repos))
            (complete-with-action
-            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '("")))
+            action candidates string predicate))) nil nil nil consult-gh--repos-history nil t)) '(""))))
       ('t
        (if repo-from-current-dir
            (list repo-from-current-dir)
@@ -1338,7 +1344,7 @@ It uses `consult-gh--make-source-from-issues' to create the list of items for co
 "Interactively clones the repo to targetdir directory. It uses the internal function `consult-gh--repo-clone' which in turn runs `gh clone repo ...`.
 If repo or targetdir are not supplied, interactively asks user for those values."
   (interactive)
-  (let* ((consult-gh-prioritize-local-folder nil)
+  (let* ((consult-gh-prioritize-local-folder (if (eq consult-gh-prioritize-local-folder 'suggest) consult-gh-prioritize-local-folder nil))
          (repos (or repos (consult-gh--read-repo-name)))
          (targetdir (or targetdir consult-gh-default-clone-directory))
          (clonedir (if consult-gh-confirm-before-clone (read-directory-name "Select Target Directory: " targetdir default-directory) targetdir)))
@@ -1354,7 +1360,7 @@ If repo or targetdir are not supplied, interactively asks user for those values.
 (defun consult-gh-repo-fork (&optional repos)
 "Interactively forks the repository defined by `repo` to the current user account logged in with `gh` command line tool after confirming name. It uses `gh fork repo ...`."
   (interactive)
-  (let* ((consult-gh-prioritize-local-folder nil)
+  (let* ((consult-gh-prioritize-local-folder (if (eq consult-gh-prioritize-local-folder 'suggest) consult-gh-prioritize-local-folder nil))
          (repos (or repos (consult-gh--read-repo-name))))
     (mapcar (lambda (repo)
               (let* ((package (car (last (split-string repo "\/"))))


### PR DESCRIPTION
- extra non-unicode characters are deleted from history list
- local repos is now added to the end of history list in consult-gh--read-repo-name and can be selected by `M-n