### PR TITLE
fix actions on `consult-gh-orgs and `consult-gh-default-repos`

### DIFF
--- a/consult-gh.org
+++ b/consult-gh.org
@@ -489,7 +489,7 @@ if IGNORE-CASE is non-nil.
                (replace-match "=\\3="))
 
               ((pred (lambda (el) (string-match-p "```.*\n[[:ascii:][:nonascii:]]*```" el)))
-               (replace-match "#+begin_src \\4\n\\5\\6\n#+end_src\n")))))))
+               (replace-match "#+begin_src \\4\n\\5\n#+end_src\n")))))))
     nil))
 #+end_src
 ***** convert links

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -2070,22 +2070,29 @@ For more details on consult--async functionalities, see `consult-grep' and the o
 **** consult-gh-orgs
 ****** Non-interactive command
 #+begin_src emacs-lisp
-(defun consult-gh-orgs (&optional orgs)
+(defun consult-gh-orgs (&optional orgs noaction)
 "List repositories of ORGS.
 This is a wrapper function around `consult-gh--repo-list'. If ORGS is nil, this simply calls `consult-gh--repo-list'. If ORGS is a list, then it runs `consult-gh--repo-list' on every member of ORGS and returns the results (repositories of all ORGS) to `consult--read'."
   (if (not orgs)
-      (consult-gh-repo-list)
-    (let* (
-        (candidates (consult--slow-operation "Collecting Repos ..."  (apply #'append (mapcar (lambda (org) (consult-gh--repo-list org)) orgs)))))
-        (consult--read candidates
+      (consult-gh-repo-list nil noaction))
+    (let* ((candidates (consult--slow-operation "Collecting Repos ..."  (apply #'append (mapcar (lambda (org) (consult-gh--repo-list org)) orgs))))
+        (sel (consult--read candidates
                     :prompt "Select Repo: "
-                    :require-match t
-                    :sort t
+                    :lookup (consult-gh--repo-lookup)
+                    :state (funcall #'consult-gh--repo-state)
                     :group #'consult-gh--repo-group
+                    :add-history (append (list (consult--async-split-initial  (consult-gh--get-repo-from-directory)) (consult--async-split-thingatpt 'symbol))
+                        consult-gh--known-repos-list
+                                  )
                     :history 'consult-gh--repos-history
+                    :require-match t
                     :category 'consult-gh-repos
                     :preview-key consult-gh-preview-key
-                    ))))
+                    :sort t
+                    )))
+    (if noaction
+        sel
+      (funcall consult-gh-repo-action sel))))
 #+end_src
 
 **** consult-gh-default-repos


### PR DESCRIPTION
When using `consult-gh-orgs` or `consult-gh-default-actions`, no actions were runing. This PR fixes that.