### PR TITLE
Removes Package-Requires in consult-gh-transient

### DIFF
--- a/consult-gh-transient.el
+++ b/consult-gh-transient.el
@@ -6,7 +6,6 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 1.1
-;; Package-Requires: ((consult-gh "1.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -4678,7 +4678,6 @@ This is a wrapper function arround `consult-gh-forge--pr-view'."
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 1.1
-;; Package-Requires: ((consult-gh "1.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 


### PR DESCRIPTION
The Package-Requires is not needed in consult-gh-transient
because its a dependency on its own package!

Fixes this comment: https://github.com/melpa/melpa/pull/9118#issuecomment-2308448991