### PR TITLE
(set-buffer-modifed-p nil) in consult-gh--repo-insert-readme

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -1945,6 +1945,7 @@ set `consult-gh-repo-action' to `consult-gh--repo-browse-url-action'."
       (when content
         (insert (base64-decode-string content))
         (set-buffer-file-coding-system 'raw-text))
+      (set-buffer-modified-p nil)
       (normal-mode)))
   nil)
 


### PR DESCRIPTION
If not set, save-some-buffers will keep asking to save the file because `buffer-file-name` is not nil.