### PR TITLE
fix typo error in repo clone action

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -3097,7 +3097,7 @@ ARGS are ignored."
                                             (message "repo %s was cloned to %s" (propertize ,repo 'face 'font-lock-keyword-face) (propertize (expand-file-name ,name ,targetdir) 'face 'font-lock-type-face)))))
                             :cmd-args (list "repo" "clone" (format "%s" repo) (expand-file-name name targetdir))))
     (let ((inhibit-message t))
-       (expand-file-name ,name ,targetdir)))
+       (expand-file-name name targetdir)))
 
 (defun consult-gh--repo-clone-action (cand)
   "Clones a repo candidate, CAND.

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -3486,7 +3486,7 @@ ARGS are ignored."
                                             (message "repo %s was cloned to %s" (propertize ,repo 'face 'font-lock-keyword-face) (propertize (expand-file-name ,name ,targetdir) 'face 'font-lock-type-face)))))
                             :cmd-args (list "repo" "clone" (format "%s" repo) (expand-file-name name targetdir))))
     (let ((inhibit-message t))
-       (expand-file-name ,name ,targetdir)))
+       (expand-file-name name targetdir)))
 #+end_src
 ******** clone action
 #+begin_src emacs-lisp


### PR DESCRIPTION
Hi. I noticed `consult-gh-repo-clone` was giving me an error and found it was caused by a small typo in the function from the latest 2.0 update.