### PR TITLE
update the consult requirements to latest consult

### DIFF
--- a/consult-gh-emacs-pr-review.el
+++ b/consult-gh-emacs-pr-review.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.2
-;; Package-Requires: ((emacs "30.0") (consult "1.9") (pr-review "0.1") (consult-gh "2.2"))
+;; Package-Requires: ((emacs "30.0") (consult "202501220") (pr-review "0.1") (consult-gh "2.2"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 

--- a/consult-gh-forge.el
+++ b/consult-gh-forge.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.2
-;; Package-Requires: ((emacs "30.0") (consult "1.9") (forge "0.3.3") (consult-gh "2.2"))
+;; Package-Requires: ((emacs "30.0") (consult "202501220") (forge "0.3.3") (consult-gh "2.2"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.0
-;; Package-Requires: ((emacs "30.0") (consult "1.9") (markdown-mode "2.6") (ox-gfm "1.0"))
+;; Package-Requires: ((emacs "30.0") (consult "202501220") (markdown-mode "2.6") (ox-gfm "1.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
 

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -13,7 +13,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.0
-;; Package-Requires: ((emacs "30.0") (consult "1.9") (markdown-mode "2.6") (ox-gfm "1.0"))
+;; Package-Requires: ((emacs "30.0") (consult "20250121.1423") (markdown-mode "2.6") (ox-gfm "1.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
 
@@ -12220,7 +12220,7 @@ CAND can be a PR or an issue."
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.2
-;; Package-Requires: ((emacs "30.0") (consult "1.9") (forge "0.3.3") (consult-gh "2.2"))
+;; Package-Requires: ((emacs "30.0") (consult "20250121.1423") (forge "0.3.3") (consult-gh "2.2"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 
@@ -12623,7 +12623,7 @@ default behavior of `ghub--host' to allow using
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.2
-;; Package-Requires: ((emacs "30.0") (consult "1.9") (pr-review "0.1") (consult-gh "2.2"))
+;; Package-Requires: ((emacs "30.0") (consult "20250121.1423") (pr-review "0.1") (consult-gh "2.2"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -2191,7 +2191,7 @@ USER defaults to `consult-gh--auth-current-active-account'."
 
 STYLE defaults to `consult-async-split-style'."
 (let ((style (or style consult-async-split-style 'none)))
-  (or (plist-get (alist-get style consult-async-split-styles-alist) :initial)
+  (or (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :initial))
       (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :separator))
       "")))
 #+end_src
@@ -8426,7 +8426,7 @@ Description of Arguments:
                                          :state (funcall #'consult-gh--repo-state)
                                          :initial initial
                                          :group #'consult-gh--repo-group
-                                         :add-history  (mapcar (lambda (item) (concat (consult-gh--get-split-style-character) item))
+                                         :add-history  (mapcar (lambda (item) (concat  (consult-gh--get-split-style-character) item))
                                                                (append (list
                                                                (when current-repo
                                                                  (consult-gh--get-username current-repo))


### PR DESCRIPTION
Because of the breaking changes in consult API, we have to upgrade the
dependency to the latest consult (which is not a stable release yet).