### PR TITLE
Exception on char-to-string

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -2008,8 +2008,8 @@ USER defaults to `consult-gh--auth-current-active-account'."
 
 STYLE defaults to `consult-async-split-style'."
 (let ((style (or style consult-async-split-style 'none)))
-  (or (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :initial))
-      (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :separator))
+  (or (plist-get (alist-get style consult-async-split-styles-alist) :initial)
+      (plist-get (alist-get style consult-async-split-styles-alist) :separator)
       "")))
 
 (defun consult-gh--get-user-info (&optional user)


### PR DESCRIPTION
Hi Armin, really great project! I'm creating this pull request using it :)

When I loaded it, I got an exception while starting up `consult-gh`, and in the debugger I found it was because of the function `consult-gh--get-split-style-character`. The Perl split style returns a string "#", and `char-to-string` throws an exception on string arguments, at least in emacs 30.

```elisp
;; ...
(wrong-type-argument characterp "#")
  char-to-string("#")
;; ...
```

I'm not sure whether this is because of new behavior in emacs 30?

I imagine you can't merge this PR as-is, but let me know what you think. (If you are reading this, the PR submission worked perfectly; thanks again for the project.)