### PR TITLE
Release Version 2.6 with GitHub Actions Support and Bug Fixes

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -3,17 +3,20 @@
 #+language: en
 
 * Development
+
+* Version 2.6 (2025-07-10)
 - Added support for workflows and runs
-  - Added support for listing workflows ("gh workflow list ...")
+  - Added support for listing workflows ("gh workflow list ...") with =consult-gh-workflow-list=
   - Added support for viewing workflows in Emacs ("gh workflow view ...")
-  - Added support for enabling/disabling workflows ("gh workflow enable/disable ...")
-  - Added support for running workflow ("gh workflow run ...")
-  - Added support for listing runs ("gh run list ...")
-  - Added suppport for viewing runs in Emacs ("gh run view ...")
+  - Added support for enabling/disabling workflows ("gh workflow enable/disable ...") with =consult-gh-workflow-enbale= or =consult-gh-workflow-disable=
+  - Added support for running workflow ("gh workflow run ...") with =consult-gh-workflow-run=
+  - Added support for listing runs ("gh run list ...") with =consult-gh-run-list=
+  - Added suppport for viewing runs in Emacs ("gh run view ...") =consult-gh-run-view=
 - Added ansi-color for seeing logs of actions runs
 - Added yaml as dependency for parsing github action files
 - Other fixes and improvements
-
+  - Fixes reading title and body in org-format
+  - Fixes getting stuck in conversion form markdown to org-mode
 
 * Version 2.5.1 (2025-06-08)
 - fixes issues with parsing titles when creating pr or issue (#232)

--- a/README.org
+++ b/README.org
@@ -404,6 +404,17 @@ Here is a screenshot showing making anew repository from scratch:
 
 Similarly you can use =consult-gh-issue-create= or =consult-gh-pr-create= to create new issues or pull requests.
 
+** Managing GitHub Actions
+Since Version 2.6, you can also manage GitHub actions from inside Emacs. You can call =consult-gh-workflow-list= to see a list of workflows, or call =consult-gh-run-list= to see a list of all actions runs. You can enable/disable actions by =consult-gh-workflow-enable= and =consult-gh-workflow-disable=. You can also manully run workflows by calling =consult-gh-workflow-run=.
+
+Here is a screenshot showing how you can list and see details of workflow runs:
+
+#+ATTR_ORG: :width 800px
+#+ATTR_LATEX: :width 800px
+#+ATTR_HTML: :width 800px
+[[https://github.com/armindarvish/consult-gh/blob/screenshots/screenshots/consult-gh-workflow.gif]]
+
+
 ** Embark Integration
 =consult-gh= also provides embark integration defined in =consult-gh-embark.el= If you use [[https://github.com/oantolin/embark][Embark]], you can use these commands for additional actions on items in consult-gh menu.
 For example, you can set your default action for repos bound to =consult-gh-repo-browse-url-action= which opens the repo's URL in a browser, but then call embark on any item for running alternative actions such as =consult-gh-repo-clone= or =consult-gh-repo-fork= etc. You can also call embark and select items with =embark-select= (by default bound to =SPC=) before running some commands on all of them, for example select multiple repos and run clone for all of them.

--- a/consult-gh-embark.el
+++ b/consult-gh-embark.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "2.5") (embark-consult "1.1"))
+;; Version: 2.6
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "2.6") (embark-consult "1.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh-forge.el
+++ b/consult-gh-forge.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "2.5"))
+;; Version: 2.6
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "2.6"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh-transient.el
+++ b/consult-gh-transient.el
@@ -5,7 +5,7 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
+;; Version: 2.6
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh-with-pr-review.el
+++ b/consult-gh-with-pr-review.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "2.5"))
+;; Version: 2.6
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "2.6"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -8926,8 +8926,7 @@ BUFFER defaults to the `current-buffer'."
          ((eq mode 'markdown-mode)
           (markdown-mode))
          ((eq mode 'org-mode)
-          (org-mode)
-          (consult-gh--org-to-markdown))
+          (org-mode))
          (t (text-mode)))
         (goto-char (or header-beg (point-min)))
         (cond
@@ -8944,7 +8943,10 @@ BUFFER defaults to the `current-buffer'."
         (when header-regions
           (cl-loop for region in header-regions
                    do (delete-region (car region) (cdr region))))
-        (setq body (string-trim (consult-gh--whole-buffer-string)))
+        (setq body (string-trim
+                    (if (eq mode 'org-mode)
+                        (consult-gh--org-to-markdown)
+                      (consult-gh--whole-buffer-string))))
 (cons title body)))))
 
 (defun consult-gh-topics--format-field-header-string (string &optional prefix suffix)
@@ -10147,8 +10149,7 @@ When SKIP-EXISTING is non-nil, does not overwrite existing files"
                      (setq args (append args (list (format "--archive=%s" archive))))))
 
         (':pattern (let ((patterns (consult--read nil
-                                                  :prompt "Enter comma separated patterns (e.g. *.deb, *.rpm): "
-                                                  )))
+                                                  :prompt "Enter comma separated patterns (e.g. *.deb, *.rpm): ")))
                      (when (and patterns
                                 (stringp patterns)
                                 (not (string-empty-p patterns)))
@@ -11377,8 +11378,7 @@ Description of Arguments:
          (updatedAt (cadr (cdddr (cdddr parts))))
          (elapsed (and startedAt updatedAt
                        (time-convert (time-subtract (date-to-time updatedAt)
-                                                    (date-to-time startedAt)
-                                                    ) 'integer)))
+                                                    (date-to-time startedAt)) 'integer)))
          (updatedAt (and updatedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time updatedAt))))
          (startedAt (and startedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time startedAt))))
          (age (consult-gh--time-ago startedAt))
@@ -11530,8 +11530,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
          (updatedAt (gethash :updated_at table))
          (elapsed (and startedAt updatedAt
                        (time-convert (time-subtract (date-to-time updatedAt)
-                                                    (date-to-time startedAt)
-                                                    ) 'integer)))
+                                                    (date-to-time startedAt)) 'integer)))
          (updatedAt (and updatedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time updatedAt))))
          (startedAt (and startedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time startedAt))))
          (age (consult-gh--time-ago startedAt)))
@@ -11574,8 +11573,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
                                                      (completedAt (gethash :completedAt step))
                                                      (elapsed (and startedAt completedAt
                                                                    (time-convert (time-subtract (date-to-time completedAt)
-                                                                                                (date-to-time startedAt)
-                                                                                                ) 'integer)))
+                                                                                                (date-to-time startedAt)) 'integer)))
                                                      (completedAt (and completedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time completedAt)))))
 
                                                 (concat  (format "%s" number) ". " name "\t" state "\t" (format "completed at %s" completedAt) "\s" (format "%ss" elapsed) "\n")))))))
@@ -11605,8 +11603,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
                                         "\t"
                                         (format "%s (%s)" name id)
                                         "\n"
-                                        steps
-                                        )))))
+                                        steps)))))
   (when (and (listp jobs) (stringp topic))
       (add-text-properties 0 1 (list :jobs jobs) topic))
   (when (listp content) (concat "# Jobs\n" (string-join content "\n") "\n"))))

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -5,7 +5,7 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
+;; Version: 2.6
 ;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -9929,8 +9929,7 @@ BUFFER defaults to the `current-buffer'."
          ((eq mode 'markdown-mode)
           (markdown-mode))
          ((eq mode 'org-mode)
-          (org-mode)
-          (consult-gh--org-to-markdown))
+          (org-mode))
          (t (text-mode)))
         (goto-char (or header-beg (point-min)))
         (cond
@@ -9947,9 +9946,11 @@ BUFFER defaults to the `current-buffer'."
         (when header-regions
           (cl-loop for region in header-regions
                    do (delete-region (car region) (cdr region))))
-        (setq body (string-trim (consult-gh--whole-buffer-string)))
+        (setq body (string-trim
+                    (if (eq mode 'org-mode)
+                        (consult-gh--org-to-markdown)
+                      (consult-gh--whole-buffer-string))))
 (cons title body)))))
-
 
 #+end_src
 
@@ -11338,8 +11339,7 @@ When SKIP-EXISTING is non-nil, does not overwrite existing files"
                      (setq args (append args (list (format "--archive=%s" archive))))))
 
         (':pattern (let ((patterns (consult--read nil
-                                                  :prompt "Enter comma separated patterns (e.g. *.deb, *.rpm): "
-                                                  )))
+                                                  :prompt "Enter comma separated patterns (e.g. *.deb, *.rpm): ")))
                      (when (and patterns
                                 (stringp patterns)
                                 (not (string-empty-p patterns)))
@@ -12710,8 +12710,7 @@ Description of Arguments:
          (updatedAt (cadr (cdddr (cdddr parts))))
          (elapsed (and startedAt updatedAt
                        (time-convert (time-subtract (date-to-time updatedAt)
-                                                    (date-to-time startedAt)
-                                                    ) 'integer)))
+                                                    (date-to-time startedAt)) 'integer)))
          (updatedAt (and updatedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time updatedAt))))
          (startedAt (and startedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time startedAt))))
          (age (consult-gh--time-ago startedAt))
@@ -12884,8 +12883,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
          (updatedAt (gethash :updated_at table))
          (elapsed (and startedAt updatedAt
                        (time-convert (time-subtract (date-to-time updatedAt)
-                                                    (date-to-time startedAt)
-                                                    ) 'integer)))
+                                                    (date-to-time startedAt)) 'integer)))
          (updatedAt (and updatedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time updatedAt))))
          (startedAt (and startedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time startedAt))))
          (age (consult-gh--time-ago startedAt)))
@@ -12932,8 +12930,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
                                                      (completedAt (gethash :completedAt step))
                                                      (elapsed (and startedAt completedAt
                                                                    (time-convert (time-subtract (date-to-time completedAt)
-                                                                                                (date-to-time startedAt)
-                                                                                                ) 'integer)))
+                                                                                                (date-to-time startedAt)) 'integer)))
                                                      (completedAt (and completedAt (format-time-string "[%Y-%m-%d %H:%M:%S]" (date-to-time completedAt)))))
 
                                                 (concat  (format "%s" number) ". " name "\t" state "\t" (format "completed at %s" completedAt) "\s" (format "%ss" elapsed) "\n")))))))
@@ -12966,8 +12963,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
                                         "\t"
                                         (format "%s (%s)" name id)
                                         "\n"
-                                        steps
-                                        )))))
+                                        steps)))))
   (when (and (listp jobs) (stringp topic))
       (add-text-properties 0 1 (list :jobs jobs) topic))
   (when (listp content) (concat "# Jobs\n" (string-join content "\n") "\n"))))

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -12,7 +12,7 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
+;; Version: 2.6
 ;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
@@ -17553,8 +17553,8 @@ This section includes additional useful embark actions as well as possible keyma
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "2.5") (embark-consult "1.1"))
+;; Version: 2.6
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "2.6") (embark-consult "1.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 
@@ -19257,8 +19257,8 @@ CAND can be a PR or an issue."
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "2.5"))
+;; Version: 2.6
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "2.6"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 
@@ -19688,8 +19688,8 @@ default behavior of `ghub--host' to allow using
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "2.5"))
+;; Version: 2.6
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "2.6"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 
@@ -19920,7 +19920,7 @@ default behavior of `ghub--host' to allow using
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 2.5
+;; Version: 2.6
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 


### PR DESCRIPTION
# Bug Fixes

-   Fixed issues with reading title and body in org-format
-   Fixed problems with getting stuck during conversion from markdown to org-mode
-   Improved code formatting and removed unnecessary whitespace


# Documentation Updates

-   Updated README.org with a new section on managing GitHub Actions
-   Added a screenshot demonstrating workflow management functionality
-   Updated CHANGELOG.org with detailed information about the new features


# Version Updates

-   Updated version numbers across all files from 2.5 to 2.6:  
    -   consult-gh.el
    -   consult-gh.org
    -   consult-gh-embark.el
    -   consult-gh-forge.el
    -   consult-gh-transient.el
    -   consult-gh-with-pr-review.el

This release continues to improve the integration between Emacs and GitHub, making it even more convenient to manage GitHub repositories and now GitHub Actions directly from Emacs.  


# Commit Messages


## (ab670d2)  fix markdown to org in topics&#x2013;get-title-and-body


## (56e8440)  update README

adds workflow section to readme  


## (1d4835d)  bump version to 2.6 and update CHANGELOG

This pull request merges the `develop` branch into `main` for the release of version 2.6 of `consult-gh`. The new version introduces significant enhancements to the package, primarily focused on adding support for GitHub Actions workflows and runs.