### PR TITLE
Add missing yaml dependency and a mention it in a note

### DIFF
--- a/README.org
+++ b/README.org
@@ -128,6 +128,9 @@ As of Emacs 27, json is available as built-in *if Emacs is compiled with json.* 
 
 *** [[https://github.com/jrblevin/markdown-mode][markdown-mode]]
 Since =gh= returns information in markdown, [[https://github.com/jrblevin/markdown-mode][markdown-mode]] is needed for seeing contents of issues, pull requests, etc. IN earlier versions markdown-mode was recommended but not required, but as of consult-gh version 2.0, =markdown-mode= is a requirement to ensure the viewing of issues and pull requests etc. work as expected.
+*** [[https://github.com/zkry/yaml.el][yaml.el]]
+
+Github actions are written in Yaml format, so we use yaml.el for parsing Github actions files.
 
 ** Installation
 

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.6
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0"))
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (yaml) (markdown-mode "2.6") (ox-gfm "1.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
 


### PR DESCRIPTION
My Emacs screamed about not finding yaml.el when I tried to load your package. Perhaps you can add yaml to package requirements so it installs automatically with your library.