### PR TITLE
Add yaml.el as a dependency for GitHub Actions workflow parsing

### DIFF
--- a/README.org
+++ b/README.org
@@ -128,6 +128,9 @@ As of Emacs 27, json is available as built-in *if Emacs is compiled with json.* 
 
 *** [[https://github.com/jrblevin/markdown-mode][markdown-mode]]
 Since =gh= returns information in markdown, [[https://github.com/jrblevin/markdown-mode][markdown-mode]] is needed for seeing contents of issues, pull requests, etc. IN earlier versions markdown-mode was recommended but not required, but as of consult-gh version 2.0, =markdown-mode= is a requirement to ensure the viewing of issues and pull requests etc. work as expected.
+*** [[https://github.com/zkry/yaml.el][yaml.el]]
+Github actions are written in YAML format, so yaml.el is needed for parsing Github action files. Particularly, it is needed for reading input varibales in the YAML content of GitHub actions when manually running workflows.
+
 
 ** Installation
 

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.6
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0"))
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0") (yaml "1.2.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
 

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -13,7 +13,7 @@
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
 ;; Version: 2.6
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0"))
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0") (yaml "1.2.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
 


### PR DESCRIPTION
This pull request adds `yaml.el` as a dependency to the `consult-gh` package to properly support parsing of GitHub Actions workflow files. GitHub Actions are defined in YAML format, and the package needs to be able to parse these files, particularly when manually running workflows that have input variables.  

closes #244.  

\## Commit Messages  
\### (9bb08ef)  Add yaml.el as a dependency for GitHub actions  

This commit adds yaml.el as a dependency to consult-gh for proper  
handling of GitHub Actions workflows. GitHub Actions are written in  
YAML format, and yaml.el is specifically needed for parsing these  
files when manually running workflows, particularly for reading input  
variables defined in the action configuration.