### PR TITLE
Add TAB keybinding to hide subdirectory in consult-gh-dired-mode

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -2236,6 +2236,7 @@ Helps with autocompleting usernames, issue numbers, etc."
   "* C-n" #'consult-gh-dired-next-marked-file
   "$" #'consult-gh-dired-hide-subdir
   "M-$" #'consult-gh-dired-hide-all
+  "TAB" #'consult-gh-dired-hide-subdir
   "<backtab>" #'consult-gh-dired-fold-cycle
   "(" #'consult-gh-dired-hide-details
   "RET" #'consult-gh-dired-find-file

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -2333,6 +2333,7 @@ Helps with autocompleting usernames, issue numbers, etc."
   "* C-n" #'consult-gh-dired-next-marked-file
   "$" #'consult-gh-dired-hide-subdir
   "M-$" #'consult-gh-dired-hide-all
+  "TAB" #'consult-gh-dired-hide-subdir
   "<backtab>" #'consult-gh-dired-fold-cycle
   "(" #'consult-gh-dired-hide-details
   "RET" #'consult-gh-dired-find-file


### PR DESCRIPTION
This pull request introduces a new keybinding for the TAB key in consult-gh-dired-mode, mapping it to the `consult-gh-dired-hide-subdir` function. This enhancement provides users with an additional, intuitive method to collapse subdirectories in the GitHub dired-like buffer.  

\## Commit Messages  
\### (8cea6a5)  Add TAB to hide subdirectory in consult-gh-dired  

This commit enhances the consult-gh-dired mode by adding a new keybinding  
for the TAB key to hide subdirectories. Previously, users could hide  
subdirectories using the "$" key, but now they have an additional,  
more intuitive method.