### PR TITLE
Fix get test propoerty incorrect arguments

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -21266,7 +21266,7 @@ For more details refer to the manual with “gh release create --help”."
   (consult-gh-with-host
    (consult-gh--auth-account-host)
   (let* ((release consult-gh--topic)
-         (type (get-text-property 0 () :type release)))
+         (type (get-text-property 0 :type release)))
     (if (equal type "release")
         (let* ((repo (get-text-property 0 :repo release))
                (meta (consult-gh-topics--release-get-metadata release))

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -23694,7 +23694,7 @@ For more details refer to the manual with “gh release create --help”."
   (consult-gh-with-host
    (consult-gh--auth-account-host)
   (let* ((release consult-gh--topic)
-         (type (get-text-property 0 () :type release)))
+         (type (get-text-property 0 :type release)))
     (if (equal type "release")
         (let* ((repo (get-text-property 0 :repo release))
                (meta (consult-gh-topics--release-get-metadata release))


### PR DESCRIPTION
\## Commit Messages  
\### (3c6f89b)  Fix \`get-text-property\` call incorrect arguments  

The \`get-text-property\` function was called with an incorrect second argument.  
Previously, an empty list \`()\` was passed as the second argument, which is  
incorrect. The correct usage requires only the position and property name.  

Fixes #261