### PR TITLE
Fix package summary for consult-gh-nerd-icons

### DIFF
--- a/consult-gh-nerd-icons.el
+++ b/consult-gh-nerd-icons.el
@@ -1,4 +1,4 @@
-;;; consult-gh-nerd-icons.el --- nerd icons Integration for consult-gh -*- lexical-binding: t -*-
+;;; consult-gh-nerd-icons.el --- Nerd icons integration for consult-gh -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2023 Armin Darvish
 

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -29163,7 +29163,7 @@ default behavior of `ghub--host' to allow using
 :END:
 ** Header
 #+begin_src  emacs-lisp
-;;; consult-gh-nerd-icons.el --- nerd icons Integration for consult-gh -*- lexical-binding: t -*-
+;;; consult-gh-nerd-icons.el --- Nerd icons integration for consult-gh -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2023 Armin Darvish
 


### PR DESCRIPTION
Addresses the issue with package-lint complaining about the package Summary.  

\## Commit Messages  
\### (7b6a9b2)  Fix package summary for consult-gh-nerd-icons  

Start package summary with Capital letter so package-lint does not  
complain.