### PR TITLE
fix: prevent underscores in file paths to mess up list of changed files in pull request review

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -12407,6 +12407,7 @@ the buffer-local variable `consult-gh--topic' in the buffer created by
             "number: " number "\n"
             "ref: " repo ":" baseRef " <- " (and headRepoOwner (concat headRepoOwner "/")) (and headRepo (format "%s:" headRepo)) headRef "\n"
             "state: " state "\n"
+            "options: ^:{}\n"
             (and createdAt (concat "created: " createdAt "\n"))
             (and updatedAt (concat "lastUpdated: " updatedAt "\n"))
             (and closedAt (concat "closed: " closedAt "\n"))


### PR DESCRIPTION
I've recently started using the `consult-gh` package. Especially the PR review feature is interesting to me since.

In the org-mode preview, file names with underscores are not readable since the text after the underscore is treated as sub-string. I disabled this feature following this suggestion 

https://necromuralist.github.io/posts/disabling-subscripting-in-org-mode/

in my own fork. This works nicely for me.