### PR TITLE
Refactor consult-gh--get-split-style-character for clarity and robustness

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -3410,12 +3410,14 @@ users))
            (keymap-unset map (car k) t)))
 
 (defun consult-gh--get-split-style-character (&optional style)
-"Get the character for consult async split STYLE.
+  "Get the character for consult async split STYLE.
 
 STYLE defaults to `consult-async-split-style'."
-(let ((style (or style consult-async-split-style 'none)))
-  (or (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :initial))
-      (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :separator))
+  (let* ((style (or style consult-async-split-style 'none))
+         (spec (alist-get style consult-async-split-styles-alist))
+         (char (or (plist-get spec :initial) (plist-get spec :separator))))
+    (if (characterp char)
+        (char-to-string char)
       "")))
 
 (defun consult-gh--get-license-list ()

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -3716,12 +3716,14 @@ users))
 ***** get consult split style character
 #+begin_src emacs-lisp
 (defun consult-gh--get-split-style-character (&optional style)
-"Get the character for consult async split STYLE.
+  "Get the character for consult async split STYLE.
 
 STYLE defaults to `consult-async-split-style'."
-(let ((style (or style consult-async-split-style 'none)))
-  (or (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :initial))
-      (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :separator))
+  (let* ((style (or style consult-async-split-style 'none))
+         (spec (alist-get style consult-async-split-styles-alist))
+         (char (or (plist-get spec :initial) (plist-get spec :separator))))
+    (if (characterp char)
+        (char-to-string char)
       "")))
 #+end_src
 ***** license


### PR DESCRIPTION
# Description

Fixes #269  

This pull request refactors the `consult-gh--get-split-style-character` function to improve code readability, maintainability, and robustness. The changes address both the main source file (`consult-gh.el`) and its corresponding documentation file (`consult-gh.org`).  


## Changes Made


### 1. Fixed Indentation

The docstring and function body indentation has been corrected to follow Emacs Lisp conventions. The docstring now properly aligns with the function definition, and the function body is consistently indented.  


### 2. Refactored Logic for Clarity

The original implementation performed nested function calls that were difficult to read and maintain:  

**Before:**  

```emacs-lisp
(let ((style (or style consult-async-split-style 'none)))
  (or (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :initial))
      (char-to-string (plist-get (alist-get style consult-async-split-styles-alist) :separator))
      ""))
```

**After:**  

```emacs-lisp
(let* ((style (or style consult-async-split-style 'none))
       (spec (alist-get style consult-async-split-styles-alist))
       (char (or (plist-get spec :initial) (plist-get spec :separator))))
  (if (characterp char)
      (char-to-string char)
    ""))
```


### 3. Key Improvements

-   **Reduced Duplication**: The `alist-get` call is now executed once and stored in `spec`, eliminating redundant lookups
-   **Intermediate Variables**: Introduced `spec` and `char` variables to break down the logic into understandable steps
-   **Type Safety**: Added explicit `(characterp char)` check before calling `char-to-string`, making the function more robust against unexpected input types
-   **Better Maintainability**: The refactored code is easier to debug, test, and modify in the future


### 4. Behavior Preservation

The refactored function maintains identical behavior to the original while being more defensive. If neither `:initial` nor `:separator` properties exist, or if they're not characters, the function safely returns an empty string.  

Both `consult-gh.el` and `consult-gh.org` have been updated consistently to maintain synchronization between the source code and documentation.  


# Commit Messages


## (b30325a)  Refactor split style character getter

Addresses #269  

Improve the `consult-gh--get-split-style-character`  
function with better code organization and style  
fixes.  

Changes made:  

-   Fixed docstring indentation to align with Emacs  
    conventions (two spaces after opening paren)
-   Refactored nested `alist-get` and `plist-get`  
    calls into intermediate variables for improved  
    readability and reduced duplication
-   Introduced `spec` variable to store the style  
    specification, eliminating redundant lookups
-   Introduced `char` variable to store the result  
    of the `or` expression for clarity
-   Replaced nested `or` with `char-to-string` calls  
    with an explicit `if` check using `characterp`  
    predicate for better type safety and clarity
-   Applied same changes to both consult-gh.el and  
    consult-gh.org documentation file for consistency

The refactored code is more maintainable, easier to  
understand, and reduces the risk of errors from  
repeated property lookups.