### PR TITLE
Replace =when-let= and =if-let= with =when-let*= and =if-let*= for proper sequencing

### DIFF
--- a/consult-gh-embark.el
+++ b/consult-gh-embark.el
@@ -242,7 +242,7 @@ The candidate can be a repo, issue, PR, file path, or a branch."
               (string-trim (concat (string-trim (consult-gh--command-to-string "browse" "--repo" (string-trim repo) "--no-browser")) (format "/tree/%s" ref))))
 
              ("release"
-              (when-let ((tagname (get-text-property 0 :tagname cand)))
+              (when-let* ((tagname (get-text-property 0 :tagname cand)))
                   (concat (string-trim (consult-gh--command-to-string "browse" "--repo" (string-trim repo) "--no-browser")) (format "/releases/%s" tagname))))
              ("workflow"
               (and (stringp path)
@@ -483,7 +483,7 @@ CAND can be a repo, issue, PR, file path, ..."
         ((or "file" "code")
          (when (not current-prefix-arg) (setq title (concat repo "/" ref "/" path))))
         ("commit"
-         (when-let ((sha (get-text-property 0 :sha cand))
+         (when-let* ((sha (get-text-property 0 :sha cand))
                     (sha-str (and (stringp sha)
                                   (substring sha 0 6))))
            (when (not current-prefix-arg) (setq title sha-str))))
@@ -553,19 +553,19 @@ CAND can be a repo, issue, PR, file path, ..."
 (defun consult-gh-embark-copy-user-name-as-kill (cand)
   "Copy the name of the user in CAND to `kill-ring'."
   (when (stringp cand)
-    (when-let ((name (consult-gh-embark-get-user-name cand)))
+    (when-let* ((name (consult-gh-embark-get-user-name cand)))
       (kill-new name))))
 
 (defun consult-gh-embark-copy-user-email-as-kill (cand)
   "Copy the email of the user in CAND to `kill-ring'."
   (when (stringp cand)
-    (when-let ((email (consult-gh-embark-get-user-email cand)))
+    (when-let* ((email (consult-gh-embark-get-user-email cand)))
       (kill-new email))))
 
 (defun consult-gh-embark-copy-user-link-as-kill (cand)
   "Copy the link of the user page in CAND to `kill-ring'."
   (when (stringp cand)
-    (when-let ((link (consult-gh-embark-get-user-link cand)))
+    (when-let* ((link (consult-gh-embark-get-user-link cand)))
       (kill-new link))))
 
 ;;;; Insert Actions
@@ -644,14 +644,14 @@ In `org-mode' or `markdown-mode',the link is formatted accordingly."
 (defun consult-gh-embark-insert-user-name (cand)
   "Insert the name of the user in CAND at point."
   (when (stringp cand)
-    (if-let ((user (consult-gh-embark-get-user-name cand)))
+    (if-let* ((user (consult-gh-embark-get-user-name cand)))
         (embark-insert (list user))
       (message "No user at point!"))))
 
 (defun consult-gh-embark-insert-user-email (cand)
   "Insert the email of the user in CAND at point."
   (when (stringp cand)
-    (if-let ((email (consult-gh-embark-get-user-email cand)))
+    (if-let* ((email (consult-gh-embark-get-user-email cand)))
         (embark-insert (list email))
       (message "No email found for user at point!"))))
 

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -2859,7 +2859,7 @@ Description of Arguments:
   (if (executable-find "gh")
       (consult-gh-with-host
        (consult-gh--auth-account-host)
-       (when-let ((proc (get-process name)))
+       (when-let* ((proc (get-process name)))
          (delete-process proc))
        (let* ((cmd-args (append (list "gh") cmd-args))
               (proc-buf (generate-new-buffer (concat consult-gh--async-process-buffer-name "-" name)))
@@ -3020,7 +3020,7 @@ If TRANSFORM is non-nil, the CAND itself is returned."
        ((member group-by '(nil :nil :none :no :not))
         nil)
        ((not (member group-by '(:t t)))
-        (if-let ((group (get-text-property 0 group-by cand)))
+        (if-let* ((group (get-text-property 0 group-by cand)))
             (format "%s" group)
           "N/A"))
        (t t)))))
@@ -3277,7 +3277,7 @@ Returns an alist with key value pairs of (file . diff)"
 
 (defun consult-gh--get-gitignore-template-content (template)
   "Get content of gitignore TEMPLATE."
-  (when-let ((response (consult-gh--command-to-string "api" (format "gitignore/templates/%s" template))))
+  (when-let* ((response (consult-gh--command-to-string "api" (format "gitignore/templates/%s" template))))
     (gethash :source (consult-gh--json-to-hashtable response))))
 
 (defun consult-gh--gitignore-template-preview (action cand)
@@ -3431,7 +3431,7 @@ Each item is a cons of (name . key) for a license."
 
 (defun consult-gh--get-license-content (license)
   "Get body of LICENSE."
-  (when-let ((response (consult-gh--command-to-string "api" (format "licenses/%s" license))))
+  (when-let* ((response (consult-gh--command-to-string "api" (format "licenses/%s" license))))
     (gethash :body (consult-gh--json-to-hashtable response))))
 
 (defun consult-gh--license-preview (action cand)
@@ -3980,7 +3980,7 @@ Completes “@.*” for mentionng users in comments, posts,..."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let (cand (car (member str (cl-remove-duplicates
+                      (when-let* (cand (car (member str (cl-remove-duplicates
                          (delq nil (append
                                     (get-text-property 0 :mentionable-users topic)
                                     (get-text-property 0 :commenters topic)))))))
@@ -4210,7 +4210,7 @@ Completes “assignees:.*” for adding assignees."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4261,7 +4261,7 @@ Completes “labels:.*” for adding labels."
                                 (list item consult-gh-label-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :valid-labels topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :valid-labels topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4298,7 +4298,7 @@ Completes “milestone:.*” for adding a milestone."
                                 (list item consult-gh-milestone-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :valid-milestones topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :valid-milestones topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4385,7 +4385,7 @@ Completes “reviewers:.*” for adding reviewers."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4528,7 +4528,7 @@ Completes “topics:.*” for adding topics."
                                 (list item consult-gh-topic-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :popular-topics topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :popular-topics topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -5691,7 +5691,7 @@ the buffer-local variable for `consult-gh--topic'."
          (tags  (when (listp table)
                   (mapcar (lambda (item)
                             (when (hash-table-p item)
-                              (if-let ((name (gethash :name item)))
+                              (if-let* ((name (gethash :name item)))
                                   (when (stringp name)
                                     (propertize name
                                                 :repo repo
@@ -6036,7 +6036,7 @@ message."
     (with-current-buffer buffer
       (consult-gh-commit-message-mode +1)
       (save-excursion
-        (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
+        (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
           (goto-char (or (car-safe (car-safe regions)) (point-min))))
         (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
         (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -6361,7 +6361,7 @@ Description of Arguments:
                              commit)
         (add-text-properties 0 1 (list :diff-buffer nil) commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                      (goto-char (car-safe (car-safe regions)))))
           (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
           (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -6556,7 +6556,7 @@ If COMMIT-MESSAGE is non-nil, it is inserted in the buffer as initial message."
      (with-current-buffer buffer
        (consult-gh-commit-message-mode +1)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -6591,7 +6591,7 @@ If COMMIT-MESSAGE is non-nil, it is inserted in the buffer as initial message."
         (add-text-properties 0 1 (list :files new-files) commit)
         (add-text-properties 0 1 (list :diff-buffer nil) commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -6614,7 +6614,7 @@ If COMMIT-MESSAGE is non-nil, it is inserted in the buffer as initial message."
           (add-text-properties 0 1 (list :files new-files) commit)
           (add-text-properties 0 1 (list :diff-buffer nil) commit)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7026,7 +7026,7 @@ message."
      (with-current-buffer buffer
        (consult-gh-commit-message-mode +1)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7058,7 +7058,7 @@ message."
         (add-text-properties 0 1 (list :files new-files)
                                commit)
 (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7084,7 +7084,7 @@ message."
                                commit)
           (add-text-properties 0 1 (list :diff-buffer nil) commit)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7324,7 +7324,7 @@ buffer generated by `consult-gh--upload-commit'."
                (and (consult-gh--upload-commit-submit files repo path commit-message ref committer-info author-info)
                     (message "Commit Submitted!")
                     (with-current-buffer buffer
-                      (when-let ((remove-topics (remove nil (mapcar (lambda (topic) (when (stringp topic)
+                      (when-let* ((remove-topics (remove nil (mapcar (lambda (topic) (when (stringp topic)
                                               (let* ((topic-repo (get-text-property 0 :repo topic))
                                                      (topic-ref (get-text-property 0 :ref topic))
                                                      (topic-path (get-text-property 0 :path topic)))
@@ -7397,7 +7397,7 @@ message."
     (with-current-buffer buffer
       (consult-gh-commit-message-mode +1)
       (save-excursion
-        (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
+        (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
           (goto-char (or (car-safe (car-safe regions)) (point-min))))
         (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
         (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7772,7 +7772,7 @@ Description of Arguments:
                                                           :test #'equal))))
         (add-text-properties 0 1 (list :files new-files) commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                      (goto-char (car-safe (car-safe regions)))))
           (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
           (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7797,7 +7797,7 @@ Description of Arguments:
         (add-text-properties 0 1 (list :files new-files)
                              commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                      (goto-char (car-safe (car-safe regions)))))
           (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
           (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7951,7 +7951,7 @@ and is used to preview or do other actions on the issue."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (sha (get-text-property 0 :sha cand))
                         (buffer (get-buffer-create consult-gh-preview-buffer-name)))
                (add-to-list 'consult-gh--preview-buffers-list buffer)
@@ -9213,7 +9213,7 @@ buffer generated by `consult-gh--files-view'."
               (add-text-properties 0 1 (list :files new-files) consult-gh--topic)
 
               (save-excursion
-                (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+                (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                            (goto-char (car-safe (car-safe regions)))))
                 (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
                 (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -9425,7 +9425,7 @@ to preview or do other actions on the repo."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (match-str (consult--build-args query))
                         (buffer (get-buffer-create consult-gh-preview-buffer-name)))
@@ -11006,7 +11006,7 @@ and is used to preview or do other actions on the issue."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (number (get-text-property 0 :number cand))
                         (match-str (consult--build-args query))
@@ -11575,7 +11575,7 @@ ISSUE defaults to `consult-gh--topic'."
         (when (stringp text-projects)
           (save-match-data
             (while (string-match ".*\\(?1:\".*?\"\\).*" text-projects)
-              (when-let ((p (match-string 1 text-projects)))
+              (when-let* ((p (match-string 1 text-projects)))
                  (if (member (string-trim p "\"" "\"") valid-projects)
                      (push p projects))
                 (setq text-projects (string-replace p "" text-projects))))
@@ -12250,7 +12250,7 @@ and is used to preview or do other actions on the pr."
           (pcase action
             ('preview
              (if (and consult-gh-show-preview cand)
-                 (when-let ((repo (get-text-property 0 :repo cand))
+                 (when-let* ((repo (get-text-property 0 :repo cand))
                             (number (get-text-property 0 :number cand))
                             (query (get-text-property 0 :query cand))
                             (match-str (consult--build-args query))
@@ -13322,7 +13322,7 @@ PR defaults to `consult-gh--topic'."
         (when (stringp text-projects)
           (save-match-data
             (while (string-match ".*\\(?1:\".*?\"\\).*" text-projects)
-              (when-let ((p (match-string 1 text-projects)))
+              (when-let* ((p (match-string 1 text-projects)))
                  (if (member (string-trim p "\"" "\"") valid-projects)
                      (push p projects))
                 (setq text-projects (string-replace p "" text-projects))))
@@ -15073,7 +15073,7 @@ and is used to preview or do other actions on the code."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (type (get-text-property 0 :type cand))
                         (number (get-text-property 0 :number cand))
                         (buffer (get-buffer-create consult-gh-preview-buffer-name)))
@@ -15333,7 +15333,7 @@ set `consult-gh-notificatios-action' to
 
 This is an internal action function that gets a notification candidate, CAND,
 from `consult-gh-notifications' and marks it as read."
-  (when-let ((thread (get-text-property 0 :thread cand)))
+  (when-let* ((thread (get-text-property 0 :thread cand)))
     (when (consult-gh--command-to-string "api" (format "notifications/threads/%s" thread) "--silent" "--method" "PATCH")
       (message "marked as read!"))))
 
@@ -15342,7 +15342,7 @@ from `consult-gh-notifications' and marks it as read."
 
 This is an internal action function that gets a notification candidate, CAND,
 from `consult-gh-notifications' and unsubscribes from the thread."
-  (when-let ((thread (get-text-property 0 :thread cand)))
+  (when-let* ((thread (get-text-property 0 :thread cand)))
     (when (consult-gh--command-to-string "api" "--method" "PUT" "-H" "Accept: application/vnd.github+json" "--paginate" "-F" "ignored=true"(format "/notifications/threads/%s/subscription" thread))
       (message "Unsubscribed!"))))
 
@@ -15351,7 +15351,7 @@ from `consult-gh-notifications' and unsubscribes from the thread."
 
 This is an internal action function that gets a notification candidate, CAND,
 from `consult-gh-notifications' and unsubscribes from the thread."
-  (when-let ((thread (get-text-property 0 :thread cand)))
+  (when-let* ((thread (get-text-property 0 :thread cand)))
     (when (consult-gh--command-to-string "api" "--method" "PUT" "-H" "Accept: application/vnd.github+json" "--paginate" "-F" "ignored=false" (format "/notifications/threads/%s/subscription" thread))
       (message "Subscribed!"))))
 
@@ -15407,7 +15407,7 @@ and is used to preview or do other actions on the issue."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (tagname (get-text-property 0 :tagname cand))
                         (match-str (consult--build-args query))
@@ -16419,7 +16419,7 @@ and is used to preview or do other actions on the workflow."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (name (get-text-property 0 :name cand))
                         (id (get-text-property 0 :id cand))
@@ -17100,7 +17100,7 @@ and is used to preview or do other actions on the run."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (name (get-text-property 0 :name cand))
                         (id (get-text-property 0 :id cand))
@@ -17534,7 +17534,7 @@ POS defaults to current point."
   "Go to the position of beginning of the file name at POS.
 
 POS defaults to current point."
-  (when-let ((p (consult-gh--dired-file-name-position pos)))
+  (when-let* ((p (consult-gh--dired-file-name-position pos)))
     (goto-char p)))
 
 (defun consult-gh--dired-hide (start end)
@@ -18091,9 +18091,9 @@ URL `https://github.com/minad/consult'."
   (let* ((prompt (or prompt "Enter User or Org Name:  "))
          (sel (consult-gh--async-repo-list prompt #'consult-gh--repo-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -18218,9 +18218,9 @@ URL `https://github.com/minad/consult'."
                     (consult-gh--async-search-repos prompt #'consult-gh--search-repos-builder initial min-input))
                 (consult-gh--async-search-repos prompt #'consult-gh--search-repos-builder initial min-input))))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -18259,10 +18259,10 @@ If PROMPT is non-nil, use it as the query prompt."
                                                    :preview-key consult-gh-preview-key
                                                    :sort t))))
 
-     (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+     (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
        (add-to-history 'consult-gh--repos-history (concat (consult-gh--get-split-style-character) reponame))
        (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--orgs-history (concat (consult-gh--get-split-style-character) username))
       (add-to-history 'consult-gh--known-orgs-list username))
 
@@ -18378,7 +18378,7 @@ If REPOS are not supplied, interactively asks user to pick them from
 
 When NOCONFIRM is non-nil, do not ask for confirmation"
   (interactive)
-  (when-let ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
+  (when-let* ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
     (consult-gh-with-host
      (consult-gh--auth-account-host)
      (consult-gh--repo-delete repo (or noconfirm (not consult-gh-confirm-before-delete-repo))))))
@@ -18395,7 +18395,7 @@ If REPOS are not supplied, interactively asks user to pick them from
 
 When NOCONFIRM is non-nil, do not ask for confirmation"
   (interactive)
-  (when-let ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
+  (when-let* ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
     (consult-gh-with-host
      (consult-gh--auth-account-host)
      (consult-gh--repo-rename repo new-name (or noconfirm (not consult-gh-confirm-before-rename-repo))))))
@@ -18629,9 +18629,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
         (sel (consult-gh--async-issue-list prompt #'consult-gh--issue-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -18754,9 +18754,9 @@ URL `https://github.com/minad/consult'."
          (consult-gh-args (if repo (append consult-gh-args `("--repo " ,(format "%s" repo))) consult-gh-args))
          (sel (consult-gh--async-search-issues prompt #'consult-gh--search-issues-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -19425,9 +19425,9 @@ URL `https://github.com/minad/consult'."
          (prompt (or prompt "Enter Repo Name:  "))
          (sel (consult-gh--async-pr-list prompt #'consult-gh--pr-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -19552,9 +19552,9 @@ URL `https://github.com/minad/consult'."
          (consult-gh-args (if repo (append consult-gh-args `("--repo " ,(format "%s" repo))) consult-gh-args))
          (sel (consult-gh--async-search-prs prompt #'consult-gh--search-prs-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -20168,9 +20168,9 @@ URL `https://github.com/minad/consult'."
          (sel (consult-gh--async-search-code prompt #'consult-gh--search-code-builder initial min-input)))
     (setq consult-gh--open-files-list nil)
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -20292,9 +20292,9 @@ Description of Arguments:
                              sel)
 
         ;;add org and repo to known lists
-        (when-let ((reponame (get-text-property 0 :repo sel)))
+        (when-let* ((reponame (get-text-property 0 :repo sel)))
           (add-to-history 'consult-gh--known-repos-list reponame))
-        (when-let ((username (get-text-property 0 :user sel)))
+        (when-let* ((username (get-text-property 0 :user sel)))
           (add-to-history 'consult-gh--known-orgs-list username))
         sel)
        ((and (stringp sel)
@@ -20312,16 +20312,16 @@ Description of Arguments:
              (or (and allow-dirs (equal (get-text-property 0 :object-type sel) "tree"))
                  (equal (get-text-property 0 :object-type sel) "blob")))
         ;;add org and repo to known lists
-        (when-let ((reponame (get-text-property 0 :repo sel)))
+        (when-let* ((reponame (get-text-property 0 :repo sel)))
           (add-to-history 'consult-gh--known-repos-list reponame))
-        (when-let ((username (get-text-property 0 :user sel)))
+        (when-let* ((username (get-text-property 0 :user sel)))
           (add-to-history 'consult-gh--known-orgs-list username))
         sel)
        (t
          ;;add org and repo to known lists
-        (when-let ((reponame (get-text-property 0 :repo sel)))
+        (when-let* ((reponame (get-text-property 0 :repo sel)))
           (add-to-history 'consult-gh--known-repos-list reponame))
-        (when-let ((username (get-text-property 0 :user sel)))
+        (when-let* ((username (get-text-property 0 :user sel)))
           (add-to-history 'consult-gh--known-orgs-list username))
         sel)))))
 
@@ -20363,9 +20363,9 @@ Description of Arguments:
                 (consult-gh--files-read-file repo ref path initial))))
     (when sel
       ;;add org and repo to known lists
-      (when-let ((reponame (get-text-property 0 :repo sel)))
+      (when-let* ((reponame (get-text-property 0 :repo sel)))
         (add-to-history 'consult-gh--known-repos-list reponame))
-      (when-let ((username (get-text-property 0 :user sel)))
+      (when-let* ((username (get-text-property 0 :user sel)))
         (add-to-history 'consult-gh--known-orgs-list username))
       (if noaction
           sel
@@ -20826,7 +20826,7 @@ Description of Arguments:
           \(passed as INITITAL to `consult--read'\)"
   (consult-gh-with-host
    (consult-gh--auth-account-host)
-   (if-let ((candidates (consult-gh--notifications-items)))
+   (if-let* ((candidates (consult-gh--notifications-items)))
        (consult--read
         candidates
         :prompt prompt
@@ -20861,9 +20861,9 @@ If PROMPT is non-nil, use it as the query prompt."
     (when (bound-and-true-p consult-gh-embark-mode)
         (setq consult-gh--last-command #'consult-gh-notifications))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -21070,9 +21070,9 @@ URL `https://github.com/minad/consult'."
   (let* ((prompt (or prompt "Search Dashboard:  "))
          (sel (consult-gh--dashboard prompt initial)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0  :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0  :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -21207,9 +21207,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
          (sel (consult-gh--async-release-list prompt #'consult-gh--release-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -21302,7 +21302,7 @@ using the internal function `consult-gh--release-delete'.
 
 When NOCONFIRM is non-nil, do not ask for confirmation"
   (interactive)
-  (when-let ((repo (or repo (get-text-property 0 :repo (consult-gh-search-repos nil t))))
+  (when-let* ((repo (or repo (get-text-property 0 :repo (consult-gh-search-repos nil t))))
              (release (or release (get-text-property 0 :tagname (consult-gh-release-list repo t)))))
     (consult-gh-with-host
      (consult-gh--auth-account-host)
@@ -21650,9 +21650,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
         (sel (consult-gh--async-workflow-list prompt #'consult-gh--workflow-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -22030,9 +22030,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
         (sel (consult-gh--async-run-list prompt (apply-partially #'consult-gh--run-list-builder workflow) initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -22214,7 +22214,7 @@ then the user is asked to chose the TOPIC interactively."
                         (add-text-properties 0 1 (list :comment-info (append info (list :subject-type "file")) :target target) newtopic))
                (error "Canceled!")))))
         ((equal target "reply")
-         (if-let (info (get-text-property (point) :consult-gh))
+         (if-let* (info (get-text-property (point) :consult-gh))
              (add-text-properties 0 1 (list :comment-info info) newtopic)))))
      (cond
       (topic
@@ -22392,7 +22392,7 @@ URL `https://github.com/magit/magit/blob/731642756f504c8a56d3775960b7af0a93c618b
   (let ((message (or commit-message (consult-gh--commit-get-buffer-message))))
     (if message
         (progn
-          (when-let ((index (ring-member log-edit-comment-ring message)))
+          (when-let* ((index (ring-member log-edit-comment-ring message)))
             (ring-remove log-edit-comment-ring index))
           (ring-insert log-edit-comment-ring message)
              (message "Message saved"))
@@ -22535,9 +22535,9 @@ If PROMPT is non-nil, use it as the query prompt."
          (prompt (or prompt (format "Select a commit [%s]:  " (propertize ref 'face 'consult-gh-branch))))
          (sel (consult-gh--commit-list repo ref nil initial prompt)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -22654,9 +22654,9 @@ URL `https://github.com/minad/consult'."
          (prompt (or prompt "Search Commits:  "))
          (sel (consult-gh--async-search-commits repo prompt #'consult-gh--search-commits-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -3046,7 +3046,7 @@ Description of Arguments:
   (if (executable-find "gh")
       (consult-gh-with-host
        (consult-gh--auth-account-host)
-       (when-let ((proc (get-process name)))
+       (when-let* ((proc (get-process name)))
          (delete-process proc))
        (let* ((cmd-args (append (list "gh") cmd-args))
               (proc-buf (generate-new-buffer (concat consult-gh--async-process-buffer-name "-" name)))
@@ -3229,7 +3229,7 @@ If TRANSFORM is non-nil, the CAND itself is returned."
        ((member group-by '(nil :nil :none :no :not))
         nil)
        ((not (member group-by '(:t t)))
-        (if-let ((group (get-text-property 0 group-by cand)))
+        (if-let* ((group (get-text-property 0 group-by cand)))
             (format "%s" group)
           "N/A"))
        (t t)))))
@@ -3547,7 +3547,7 @@ Returns an alist with key value pairs of (file . diff)"
 #+begin_src emacs-lisp
 (defun consult-gh--get-gitignore-template-content (template)
   "Get content of gitignore TEMPLATE."
-  (when-let ((response (consult-gh--command-to-string "api" (format "gitignore/templates/%s" template))))
+  (when-let* ((response (consult-gh--command-to-string "api" (format "gitignore/templates/%s" template))))
     (gethash :source (consult-gh--json-to-hashtable response))))
 #+end_src
 ****** preview
@@ -3744,7 +3744,7 @@ Each item is a cons of (name . key) for a license."
 #+begin_src emacs-lisp
 (defun consult-gh--get-license-content (license)
   "Get body of LICENSE."
-  (when-let ((response (consult-gh--command-to-string "api" (format "licenses/%s" license))))
+  (when-let* ((response (consult-gh--command-to-string "api" (format "licenses/%s" license))))
     (gethash :body (consult-gh--json-to-hashtable response))))
 #+end_src
 ****** preview
@@ -4434,7 +4434,7 @@ Completes “@.*” for mentionng users in comments, posts,..."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let (cand (car (member str (cl-remove-duplicates
+                      (when-let* (cand (car (member str (cl-remove-duplicates
                          (delq nil (append
                                     (get-text-property 0 :mentionable-users topic)
                                     (get-text-property 0 :commenters topic)))))))
@@ -4686,7 +4686,7 @@ Completes “assignees:.*” for adding assignees."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4740,7 +4740,7 @@ Completes “labels:.*” for adding labels."
                                 (list item consult-gh-label-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :valid-labels topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :valid-labels topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4780,7 +4780,7 @@ Completes “milestone:.*” for adding a milestone."
                                 (list item consult-gh-milestone-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :valid-milestones topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :valid-milestones topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -4873,7 +4873,7 @@ Completes “reviewers:.*” for adding reviewers."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :assignable-users topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -5031,7 +5031,7 @@ Completes “topics:.*” for adding topics."
                                 (list item consult-gh-topic-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let ((cand (car (member str (delq nil (get-text-property 0 :popular-topics topic))))))
+                      (when-let* ((cand (car (member str (delq nil (get-text-property 0 :popular-topics topic))))))
                         (and (stringp cand)
                              (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand))
@@ -6340,7 +6340,7 @@ the buffer-local variable for `consult-gh--topic'."
          (tags  (when (listp table)
                   (mapcar (lambda (item)
                             (when (hash-table-p item)
-                              (if-let ((name (gethash :name item)))
+                              (if-let* ((name (gethash :name item)))
                                   (when (stringp name)
                                     (propertize name
                                                 :repo repo
@@ -6719,7 +6719,7 @@ message."
     (with-current-buffer buffer
       (consult-gh-commit-message-mode +1)
       (save-excursion
-        (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
+        (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
           (goto-char (or (car-safe (car-safe regions)) (point-min))))
         (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
         (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7062,7 +7062,7 @@ Description of Arguments:
                              commit)
         (add-text-properties 0 1 (list :diff-buffer nil) commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                      (goto-char (car-safe (car-safe regions)))))
           (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
           (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7268,7 +7268,7 @@ If COMMIT-MESSAGE is non-nil, it is inserted in the buffer as initial message."
      (with-current-buffer buffer
        (consult-gh-commit-message-mode +1)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7305,7 +7305,7 @@ If COMMIT-MESSAGE is non-nil, it is inserted in the buffer as initial message."
         (add-text-properties 0 1 (list :files new-files) commit)
         (add-text-properties 0 1 (list :diff-buffer nil) commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7331,7 +7331,7 @@ If COMMIT-MESSAGE is non-nil, it is inserted in the buffer as initial message."
           (add-text-properties 0 1 (list :files new-files) commit)
           (add-text-properties 0 1 (list :diff-buffer nil) commit)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7768,7 +7768,7 @@ message."
      (with-current-buffer buffer
        (consult-gh-commit-message-mode +1)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7803,7 +7803,7 @@ message."
         (add-text-properties 0 1 (list :files new-files)
                                commit)
 (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -7833,7 +7833,7 @@ message."
                                commit)
           (add-text-properties 0 1 (list :diff-buffer nil) commit)
        (save-excursion
-         (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+         (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                     (goto-char (car-safe (car-safe regions)))))
          (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
        (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -8086,7 +8086,7 @@ buffer generated by `consult-gh--upload-commit'."
                (and (consult-gh--upload-commit-submit files repo path commit-message ref committer-info author-info)
                     (message "Commit Submitted!")
                     (with-current-buffer buffer
-                      (when-let ((remove-topics (remove nil (mapcar (lambda (topic) (when (stringp topic)
+                      (when-let* ((remove-topics (remove nil (mapcar (lambda (topic) (when (stringp topic)
                                               (let* ((topic-repo (get-text-property 0 :repo topic))
                                                      (topic-ref (get-text-property 0 :ref topic))
                                                      (topic-path (get-text-property 0 :path topic)))
@@ -8168,7 +8168,7 @@ message."
     (with-current-buffer buffer
       (consult-gh-commit-message-mode +1)
       (save-excursion
-        (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
+        (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions)))
           (goto-char (or (car-safe (car-safe regions)) (point-min))))
         (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
         (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -8558,7 +8558,7 @@ Description of Arguments:
                                                           :test #'equal))))
         (add-text-properties 0 1 (list :files new-files) commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                      (goto-char (car-safe (car-safe regions)))))
           (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
           (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -8587,7 +8587,7 @@ Description of Arguments:
         (add-text-properties 0 1 (list :files new-files)
                              commit)
         (save-excursion
-          (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+          (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                      (goto-char (car-safe (car-safe regions)))))
           (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
           (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -8756,7 +8756,7 @@ and is used to preview or do other actions on the issue."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (sha (get-text-property 0 :sha cand))
                         (buffer (get-buffer-create consult-gh-preview-buffer-name)))
                (add-to-list 'consult-gh--preview-buffers-list buffer)
@@ -10161,7 +10161,7 @@ buffer generated by `consult-gh--files-view'."
               (add-text-properties 0 1 (list :files new-files) consult-gh--topic)
 
               (save-excursion
-                (when-let ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
+                (when-let* ((regions (consult-gh--get-region-with-prop ':consult-gh-commit-instructions))
                            (goto-char (car-safe (car-safe regions)))))
                 (consult-gh--delete-region-with-prop ':consult-gh-commit-instructions)
                 (insert (propertize consult-gh-commit-message-instructions :consult-gh-commit-instructions t))
@@ -10413,7 +10413,7 @@ to preview or do other actions on the repo."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (match-str (consult--build-args query))
                         (buffer (get-buffer-create consult-gh-preview-buffer-name)))
@@ -12166,7 +12166,7 @@ and is used to preview or do other actions on the issue."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (number (get-text-property 0 :number cand))
                         (match-str (consult--build-args query))
@@ -12799,7 +12799,7 @@ ISSUE defaults to `consult-gh--topic'."
         (when (stringp text-projects)
           (save-match-data
             (while (string-match ".*\\(?1:\".*?\"\\).*" text-projects)
-              (when-let ((p (match-string 1 text-projects)))
+              (when-let* ((p (match-string 1 text-projects)))
                  (if (member (string-trim p "\"" "\"") valid-projects)
                      (push p projects))
                 (setq text-projects (string-replace p "" text-projects))))
@@ -13533,7 +13533,7 @@ and is used to preview or do other actions on the pr."
           (pcase action
             ('preview
              (if (and consult-gh-show-preview cand)
-                 (when-let ((repo (get-text-property 0 :repo cand))
+                 (when-let* ((repo (get-text-property 0 :repo cand))
                             (number (get-text-property 0 :number cand))
                             (query (get-text-property 0 :query cand))
                             (match-str (consult--build-args query))
@@ -14747,7 +14747,7 @@ PR defaults to `consult-gh--topic'."
         (when (stringp text-projects)
           (save-match-data
             (while (string-match ".*\\(?1:\".*?\"\\).*" text-projects)
-              (when-let ((p (match-string 1 text-projects)))
+              (when-let* ((p (match-string 1 text-projects)))
                  (if (member (string-trim p "\"" "\"") valid-projects)
                      (push p projects))
                 (setq text-projects (string-replace p "" text-projects))))
@@ -16693,7 +16693,7 @@ and is used to preview or do other actions on the code."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (type (get-text-property 0 :type cand))
                         (number (get-text-property 0 :number cand))
                         (buffer (get-buffer-create consult-gh-preview-buffer-name)))
@@ -17004,7 +17004,7 @@ set `consult-gh-notificatios-action' to
 
 This is an internal action function that gets a notification candidate, CAND,
 from `consult-gh-notifications' and marks it as read."
-  (when-let ((thread (get-text-property 0 :thread cand)))
+  (when-let* ((thread (get-text-property 0 :thread cand)))
     (when (consult-gh--command-to-string "api" (format "notifications/threads/%s" thread) "--silent" "--method" "PATCH")
       (message "marked as read!"))))
 
@@ -17016,7 +17016,7 @@ from `consult-gh-notifications' and marks it as read."
 
 This is an internal action function that gets a notification candidate, CAND,
 from `consult-gh-notifications' and unsubscribes from the thread."
-  (when-let ((thread (get-text-property 0 :thread cand)))
+  (when-let* ((thread (get-text-property 0 :thread cand)))
     (when (consult-gh--command-to-string "api" "--method" "PUT" "-H" "Accept: application/vnd.github+json" "--paginate" "-F" "ignored=true"(format "/notifications/threads/%s/subscription" thread))
       (message "Unsubscribed!"))))
 #+end_src
@@ -17027,7 +17027,7 @@ from `consult-gh-notifications' and unsubscribes from the thread."
 
 This is an internal action function that gets a notification candidate, CAND,
 from `consult-gh-notifications' and unsubscribes from the thread."
-  (when-let ((thread (get-text-property 0 :thread cand)))
+  (when-let* ((thread (get-text-property 0 :thread cand)))
     (when (consult-gh--command-to-string "api" "--method" "PUT" "-H" "Accept: application/vnd.github+json" "--paginate" "-F" "ignored=false" (format "/notifications/threads/%s/subscription" thread))
       (message "Subscribed!"))))
 #+end_src
@@ -17088,7 +17088,7 @@ and is used to preview or do other actions on the issue."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (tagname (get-text-property 0 :tagname cand))
                         (match-str (consult--build-args query))
@@ -18222,7 +18222,7 @@ and is used to preview or do other actions on the workflow."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (name (get-text-property 0 :name cand))
                         (id (get-text-property 0 :id cand))
@@ -18989,7 +18989,7 @@ and is used to preview or do other actions on the run."
       (pcase action
         ('preview
          (if (and consult-gh-show-preview cand)
-             (when-let ((repo (get-text-property 0 :repo cand))
+             (when-let* ((repo (get-text-property 0 :repo cand))
                         (query (get-text-property 0 :query cand))
                         (name (get-text-property 0 :name cand))
                         (id (get-text-property 0 :id cand))
@@ -19505,7 +19505,7 @@ POS defaults to current point."
   "Go to the position of beginning of the file name at POS.
 
 POS defaults to current point."
-  (when-let ((p (consult-gh--dired-file-name-position pos)))
+  (when-let* ((p (consult-gh--dired-file-name-position pos)))
     (goto-char p)))
 #+end_src
 
@@ -20123,9 +20123,9 @@ URL `https://github.com/minad/consult'."
   (let* ((prompt (or prompt "Enter User or Org Name:  "))
          (sel (consult-gh--async-repo-list prompt #'consult-gh--repo-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -20268,9 +20268,9 @@ URL `https://github.com/minad/consult'."
                     (consult-gh--async-search-repos prompt #'consult-gh--search-repos-builder initial min-input))
                 (consult-gh--async-search-repos prompt #'consult-gh--search-repos-builder initial min-input))))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -20314,10 +20314,10 @@ If PROMPT is non-nil, use it as the query prompt."
                                                    :preview-key consult-gh-preview-key
                                                    :sort t))))
 
-     (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+     (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
        (add-to-history 'consult-gh--repos-history (concat (consult-gh--get-split-style-character) reponame))
        (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--orgs-history (concat (consult-gh--get-split-style-character) username))
       (add-to-history 'consult-gh--known-orgs-list username))
 
@@ -20458,7 +20458,7 @@ If REPOS are not supplied, interactively asks user to pick them from
 
 When NOCONFIRM is non-nil, do not ask for confirmation"
   (interactive)
-  (when-let ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
+  (when-let* ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
     (consult-gh-with-host
      (consult-gh--auth-account-host)
      (consult-gh--repo-delete repo (or noconfirm (not consult-gh-confirm-before-delete-repo))))))
@@ -20479,7 +20479,7 @@ If REPOS are not supplied, interactively asks user to pick them from
 
 When NOCONFIRM is non-nil, do not ask for confirmation"
   (interactive)
-  (when-let ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
+  (when-let* ((repo (or repo (substring-no-properties (get-text-property 0 :repo (consult-gh-user-repos nil t))))))
     (consult-gh-with-host
      (consult-gh--auth-account-host)
      (consult-gh--repo-rename repo new-name (or noconfirm (not consult-gh-confirm-before-rename-repo))))))
@@ -20739,9 +20739,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
         (sel (consult-gh--async-issue-list prompt #'consult-gh--issue-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -20881,9 +20881,9 @@ URL `https://github.com/minad/consult'."
          (consult-gh-args (if repo (append consult-gh-args `("--repo " ,(format "%s" repo))) consult-gh-args))
          (sel (consult-gh--async-search-issues prompt #'consult-gh--search-issues-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -21628,9 +21628,9 @@ URL `https://github.com/minad/consult'."
          (prompt (or prompt "Enter Repo Name:  "))
          (sel (consult-gh--async-pr-list prompt #'consult-gh--pr-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -21774,9 +21774,9 @@ URL `https://github.com/minad/consult'."
          (consult-gh-args (if repo (append consult-gh-args `("--repo " ,(format "%s" repo))) consult-gh-args))
          (sel (consult-gh--async-search-prs prompt #'consult-gh--search-prs-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -22475,9 +22475,9 @@ URL `https://github.com/minad/consult'."
          (sel (consult-gh--async-search-code prompt #'consult-gh--search-code-builder initial min-input)))
     (setq consult-gh--open-files-list nil)
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -22605,9 +22605,9 @@ Description of Arguments:
                              sel)
 
         ;;add org and repo to known lists
-        (when-let ((reponame (get-text-property 0 :repo sel)))
+        (when-let* ((reponame (get-text-property 0 :repo sel)))
           (add-to-history 'consult-gh--known-repos-list reponame))
-        (when-let ((username (get-text-property 0 :user sel)))
+        (when-let* ((username (get-text-property 0 :user sel)))
           (add-to-history 'consult-gh--known-orgs-list username))
         sel)
        ((and (stringp sel)
@@ -22625,16 +22625,16 @@ Description of Arguments:
              (or (and allow-dirs (equal (get-text-property 0 :object-type sel) "tree"))
                  (equal (get-text-property 0 :object-type sel) "blob")))
         ;;add org and repo to known lists
-        (when-let ((reponame (get-text-property 0 :repo sel)))
+        (when-let* ((reponame (get-text-property 0 :repo sel)))
           (add-to-history 'consult-gh--known-repos-list reponame))
-        (when-let ((username (get-text-property 0 :user sel)))
+        (when-let* ((username (get-text-property 0 :user sel)))
           (add-to-history 'consult-gh--known-orgs-list username))
         sel)
        (t
          ;;add org and repo to known lists
-        (when-let ((reponame (get-text-property 0 :repo sel)))
+        (when-let* ((reponame (get-text-property 0 :repo sel)))
           (add-to-history 'consult-gh--known-repos-list reponame))
-        (when-let ((username (get-text-property 0 :user sel)))
+        (when-let* ((username (get-text-property 0 :user sel)))
           (add-to-history 'consult-gh--known-orgs-list username))
         sel)))))
 #+end_src
@@ -22679,9 +22679,9 @@ Description of Arguments:
                 (consult-gh--files-read-file repo ref path initial))))
     (when sel
       ;;add org and repo to known lists
-      (when-let ((reponame (get-text-property 0 :repo sel)))
+      (when-let* ((reponame (get-text-property 0 :repo sel)))
         (add-to-history 'consult-gh--known-repos-list reponame))
-      (when-let ((username (get-text-property 0 :user sel)))
+      (when-let* ((username (get-text-property 0 :user sel)))
         (add-to-history 'consult-gh--known-orgs-list username))
       (if noaction
           sel
@@ -23173,7 +23173,7 @@ Description of Arguments:
           \(passed as INITITAL to `consult--read'\)"
   (consult-gh-with-host
    (consult-gh--auth-account-host)
-   (if-let ((candidates (consult-gh--notifications-items)))
+   (if-let* ((candidates (consult-gh--notifications-items)))
        (consult--read
         candidates
         :prompt prompt
@@ -23212,9 +23212,9 @@ If PROMPT is non-nil, use it as the query prompt."
     (when (bound-and-true-p consult-gh-embark-mode)
         (setq consult-gh--last-command #'consult-gh-notifications))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -23474,9 +23474,9 @@ URL `https://github.com/minad/consult'."
   (let* ((prompt (or prompt "Search Dashboard:  "))
          (sel (consult-gh--dashboard prompt initial)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0  :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0  :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -23630,9 +23630,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
          (sel (consult-gh--async-release-list prompt #'consult-gh--release-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -23736,7 +23736,7 @@ using the internal function `consult-gh--release-delete'.
 
 When NOCONFIRM is non-nil, do not ask for confirmation"
   (interactive)
-  (when-let ((repo (or repo (get-text-property 0 :repo (consult-gh-search-repos nil t))))
+  (when-let* ((repo (or repo (get-text-property 0 :repo (consult-gh-search-repos nil t))))
              (release (or release (get-text-property 0 :tagname (consult-gh-release-list repo t)))))
     (consult-gh-with-host
      (consult-gh--auth-account-host)
@@ -24121,9 +24121,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
         (sel (consult-gh--async-workflow-list prompt #'consult-gh--workflow-list-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -24545,9 +24545,9 @@ URL `https://github.com/minad/consult'"
   (let* ((prompt (or prompt "Enter Repo Name:  "))
         (sel (consult-gh--async-run-list prompt (apply-partially #'consult-gh--run-list-builder workflow) initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -24753,7 +24753,7 @@ then the user is asked to chose the TOPIC interactively."
                         (add-text-properties 0 1 (list :comment-info (append info (list :subject-type "file")) :target target) newtopic))
                (error "Canceled!")))))
         ((equal target "reply")
-         (if-let (info (get-text-property (point) :consult-gh))
+         (if-let* (info (get-text-property (point) :consult-gh))
              (add-text-properties 0 1 (list :comment-info info) newtopic)))))
      (cond
       (topic
@@ -24951,7 +24951,7 @@ URL `https://github.com/magit/magit/blob/731642756f504c8a56d3775960b7af0a93c618b
   (let ((message (or commit-message (consult-gh--commit-get-buffer-message))))
     (if message
         (progn
-          (when-let ((index (ring-member log-edit-comment-ring message)))
+          (when-let* ((index (ring-member log-edit-comment-ring message)))
             (ring-remove log-edit-comment-ring index))
           (ring-insert log-edit-comment-ring message)
              (message "Message saved"))
@@ -25120,9 +25120,9 @@ If PROMPT is non-nil, use it as the query prompt."
          (prompt (or prompt (format "Select a commit [%s]:  " (propertize ref 'face 'consult-gh-branch))))
          (sel (consult-gh--commit-list repo ref nil initial prompt)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -25258,9 +25258,9 @@ URL `https://github.com/minad/consult'."
          (prompt (or prompt "Search Commits:  "))
          (sel (consult-gh--async-search-commits repo prompt #'consult-gh--search-commits-builder initial min-input)))
     ;;add org and repo to known lists
-    (when-let ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
+    (when-let* ((reponame (and (stringp sel) (get-text-property 0 :repo sel))))
       (add-to-history 'consult-gh--known-repos-list reponame))
-    (when-let ((username (and (stringp sel) (get-text-property 0 :user sel))))
+    (when-let* ((username (and (stringp sel) (get-text-property 0 :user sel))))
       (add-to-history 'consult-gh--known-orgs-list username))
     (if noaction
         sel
@@ -26778,7 +26778,7 @@ The candidate can be a repo, issue, PR, file path, or a branch."
               (string-trim (concat (string-trim (consult-gh--command-to-string "browse" "--repo" (string-trim repo) "--no-browser")) (format "/tree/%s" ref))))
 
              ("release"
-              (when-let ((tagname (get-text-property 0 :tagname cand)))
+              (when-let* ((tagname (get-text-property 0 :tagname cand)))
                   (concat (string-trim (consult-gh--command-to-string "browse" "--repo" (string-trim repo) "--no-browser")) (format "/releases/%s" tagname))))
              ("workflow"
               (and (stringp path)
@@ -27031,7 +27031,7 @@ CAND can be a repo, issue, PR, file path, ..."
         ((or "file" "code")
          (when (not current-prefix-arg) (setq title (concat repo "/" ref "/" path))))
         ("commit"
-         (when-let ((sha (get-text-property 0 :sha cand))
+         (when-let* ((sha (get-text-property 0 :sha cand))
                     (sha-str (and (stringp sha)
                                   (substring sha 0 6))))
            (when (not current-prefix-arg) (setq title sha-str))))
@@ -27101,19 +27101,19 @@ CAND can be a repo, issue, PR, file path, ..."
 (defun consult-gh-embark-copy-user-name-as-kill (cand)
   "Copy the name of the user in CAND to `kill-ring'."
   (when (stringp cand)
-    (when-let ((name (consult-gh-embark-get-user-name cand)))
+    (when-let* ((name (consult-gh-embark-get-user-name cand)))
       (kill-new name))))
 
 (defun consult-gh-embark-copy-user-email-as-kill (cand)
   "Copy the email of the user in CAND to `kill-ring'."
   (when (stringp cand)
-    (when-let ((email (consult-gh-embark-get-user-email cand)))
+    (when-let* ((email (consult-gh-embark-get-user-email cand)))
       (kill-new email))))
 
 (defun consult-gh-embark-copy-user-link-as-kill (cand)
   "Copy the link of the user page in CAND to `kill-ring'."
   (when (stringp cand)
-    (when-let ((link (consult-gh-embark-get-user-link cand)))
+    (when-let* ((link (consult-gh-embark-get-user-link cand)))
       (kill-new link))))
 #+end_src
 
@@ -27197,14 +27197,14 @@ In `org-mode' or `markdown-mode',the link is formatted accordingly."
 (defun consult-gh-embark-insert-user-name (cand)
   "Insert the name of the user in CAND at point."
   (when (stringp cand)
-    (if-let ((user (consult-gh-embark-get-user-name cand)))
+    (if-let* ((user (consult-gh-embark-get-user-name cand)))
         (embark-insert (list user))
       (message "No user at point!"))))
 
 (defun consult-gh-embark-insert-user-email (cand)
   "Insert the email of the user in CAND at point."
   (when (stringp cand)
-    (if-let ((email (consult-gh-embark-get-user-email cand)))
+    (if-let* ((email (consult-gh-embark-get-user-email cand)))
         (embark-insert (list email))
       (message "No email found for user at point!"))))
 


### PR DESCRIPTION
# Description

Fixes #268  
This pull request updates the codebase to use `when-let*` and `if-let*` instead of their single-asterisk counterparts throughout `consult-gh.el`, `consult-gh-embark.el`, and `consult-gh.org`.  


## Rationale

The `when-let*` and `if-let*` macros provide sequential binding semantics, allowing later bindings to reference earlier ones in the same form. This is important when you have dependent variable bindings where one binding depends on the result of a previous one.  

**Example of the difference:**  

```elisp
;; Using when-let (parallel bindings - later vars can't reference earlier ones)
(when-let ((x (get-value))
           (y (process x)))  ;; ERROR: x is not yet bound
  (do-something x y))

;; Using when-let* (sequential bindings - later vars can reference earlier ones)
(when-let* ((x (get-value))
            (y (process x)))  ;; OK: x is bound from previous line
  (do-something x y))
```


## Changes Made

The PR systematically replaces all instances of:  

-   `when-let (` with `when-let* (`
-   `if-let (` with `if-let* (`

This affects approximately 100+ locations across the three files, including:  

1.  **consult-gh.el** - Main library file with core functionality
2.  **consult-gh-embark.el** - Embark integration module
3.  **consult-gh.org** - Literate programming documentation


## Examples of Updated Code

**Before:**  

```elisp
(when-let ((proc (get-process name)))
  (delete-process proc))
```

**After:**  

```elisp
(when-let* ((proc (get-process name)))
  (delete-process proc))
```

**Before:**  

```elisp
(if-let ((group (get-text-property 0 group-by cand)))
    (format "%s" group)
  "N/A")
```

**After:**  

```elisp
(if-let* ((group (get-text-property 0 group-by cand)))
    (format "%s" group)
  "N/A")
```


## Impact

This change improves code correctness and clarity by using the appropriate macro for the binding semantics being used. While many of these cases may work with either version, using `when-let*` and `if-let*` is the more explicit and correct choice when sequential binding is intended, and it prevents potential bugs if future code modifications introduce dependencies between bindings.  


# Commit Messages


## (4e589b9)  Update to `if-let*` and `when-let*`

Fixes #268  
This commit updates all instances of `when-let` to `when-let*` and  
`if-let` to `if-let*` throughout the codebase. The starred variants  
allow for sequential binding of variables where each binding can  
depend on the previous one, providing more flexible and expressive  
conditional logic.  

The change affects multiple files:  

-   consult-gh-embark.el: Updates in embark action functions for  
    user operations and comment handling
-   consult-gh.el: Updates across numerous functions including async  
    process handling, preview functions, notification actions, and  
    history management
-   consult-gh.org: Documentation file with corresponding updates

Example of the improvement:  
Before: `(when-let ((x (foo)) (y (bar x))) ...)`  
After:  `(when-let* ((x (foo)) (y (bar x))) ...)`  

With `when-let*`, the binding of `y` can now properly reference  
the value of `x` from the previous binding, making the code more  
intuitive and eliminating potential issues with variable scoping  
in complex conditional expressions.