### PR TITLE
Fix syntax errors in =when-let*= and =if-let*= binding forms

### DIFF
--- a/consult-gh.el
+++ b/consult-gh.el
@@ -3980,10 +3980,10 @@ Completes “@.*” for mentionng users in comments, posts,..."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let* (cand (car (member str (cl-remove-duplicates
+                      (when-let* ((cand (car (member str (cl-remove-duplicates
                          (delq nil (append
                                     (get-text-property 0 :mentionable-users topic)
-                                    (get-text-property 0 :commenters topic)))))))
+                                    (get-text-property 0 :commenters topic))))))))
                       (and (stringp cand)
                            (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand)))
@@ -22214,7 +22214,7 @@ then the user is asked to chose the TOPIC interactively."
                         (add-text-properties 0 1 (list :comment-info (append info (list :subject-type "file")) :target target) newtopic))
                (error "Canceled!")))))
         ((equal target "reply")
-         (if-let* (info (get-text-property (point) :consult-gh))
+         (if-let* ((info (get-text-property (point) :consult-gh)))
              (add-text-properties 0 1 (list :comment-info info) newtopic)))))
      (cond
       (topic

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -4434,10 +4434,10 @@ Completes “@.*” for mentionng users in comments, posts,..."
                                 (list item consult-gh-user-icon ""))
                               list)))
          (exit-fun (lambda (str _status)
-                      (when-let* (cand (car (member str (cl-remove-duplicates
+                      (when-let* ((cand (car (member str (cl-remove-duplicates
                          (delq nil (append
                                     (get-text-property 0 :mentionable-users topic)
-                                    (get-text-property 0 :commenters topic)))))))
+                                    (get-text-property 0 :commenters topic))))))))
                       (and (stringp cand)
                            (add-text-properties (- (point) (length str)) (point)
                                           (text-properties-at 0 cand)))
@@ -24753,7 +24753,7 @@ then the user is asked to chose the TOPIC interactively."
                         (add-text-properties 0 1 (list :comment-info (append info (list :subject-type "file")) :target target) newtopic))
                (error "Canceled!")))))
         ((equal target "reply")
-         (if-let* (info (get-text-property (point) :consult-gh))
+         (if-let* ((info (get-text-property (point) :consult-gh)))
              (add-text-properties 0 1 (list :comment-info info) newtopic)))))
      (cond
       (topic


### PR DESCRIPTION
# Description

This pull request fixes two instances of incorrect binding syntax in `when-let*`  
and `if-let*` forms in both `consult-gh.el` and its corresponding literate  
programming source file `consult-gh.org`.  


## Background

In Emacs Lisp, both `when-let*` and `if-let*` require their bindings to be  
wrapped in an outer list, with each individual binding also wrapped in its own  
list. The correct syntax is:  

```elisp
;; Correct syntax
(when-let* ((var1 expr1)
            (var2 expr2))
  body)

(if-let* ((var expr))
    then-form
  else-form)
```

The incorrect syntax (missing the outer parentheses around each binding pair)  
would cause these macros to misinterpret their arguments, leading to runtime  
errors or unexpected behavior:  

```elisp
;; Incorrect syntax - missing parentheses around binding pairs
(when-let* (var1 expr1)  ;; WRONG
  body)

(if-let* (var expr)  ;; WRONG
    then-form)
```


## Changes


### Fix 1: `when-let*` in mention completion exit function

The `exit-fun` lambda used for completing `@`-mentions of users in comments and  
posts had a malformed `when-let*` binding. The `cand` variable binding was  
missing its enclosing parentheses.  

**Before:**  

```elisp
(exit-fun (lambda (str _status)
            (when-let* (cand (car (member str (cl-remove-duplicates
                           (delq nil (append
                                      (get-text-property 0 :mentionable-users topic)
                                      (get-text-property 0 :commenters topic)))))))
              (and (stringp cand)
                   (add-text-properties (- (point) (length str)) (point)
                                  (text-properties-at 0 cand))))))
```

**After:**  

```elisp
(exit-fun (lambda (str _status)
            (when-let* ((cand (car (member str (cl-remove-duplicates
                           (delq nil (append
                                      (get-text-property 0 :mentionable-users topic)
                                      (get-text-property 0 :commenters topic))))))))
              (and (stringp cand)
                   (add-text-properties (- (point) (length str)) (point)
                                  (text-properties-at 0 cand))))))
```

This fix ensures that when a user selects a mention candidate (e.g., `@someuser`),  
the `cand` variable is correctly bound to the matching string from the combined  
list of mentionable users and commenters. Without this fix, `when-let*` would  
treat `cand` as the binding list and `(car ...)` as the body condition, causing  
incorrect behavior.  


### Fix 2: `if-let*` in reply comment target handling

The reply target branch of the comment topic handler had a malformed `if-let*`  
binding. The `info` variable binding was missing its enclosing parentheses.  

**Before:**  

```elisp
((equal target "reply")
 (if-let* (info (get-text-property (point) :consult-gh))
     (add-text-properties 0 1 (list :comment-info info) newtopic)))
```

**After:**  

```elisp
((equal target "reply")
 (if-let* ((info (get-text-property (point) :consult-gh)))
     (add-text-properties 0 1 (list :comment-info info) newtopic)))
```

This fix ensures that when the target is `"reply"`, the `:consult-gh` text  
property at point is correctly bound to `info` and subsequently used to set  
the `:comment-info` property on `newtopic`. Without this fix, `if-let*` would  
misinterpret the binding form, causing the reply comment functionality to fail.  


## Files Changed

Both fixes are applied symmetrically to:  

-   `consult-gh.el` — the compiled/distributed Emacs Lisp source file
-   `consult-gh.org` — the literate programming Org source file from which  
    `consult-gh.el` is generated


## Impact

These are correctness bug fixes. The affected code paths handle:  

1.  User mention (`@user`) autocompletion in issue/PR comment buffers
2.  Reply-to-comment functionality in the GitHub comment interface

Both features would have exhibited broken or undefined behavior due to the  
malformed binding syntax prior to this fix.  


# Commit Messages


## (fedc274)  Fix `when-let*` and `if-let*` binding syntax

Correct the binding list syntax for `when-let*` and `if-let*`  
macros in both `consult-gh.el` and `consult-gh.org`.  

In Emacs Lisp, `when-let*` and `if-let*` require their bindings  
to be wrapped in an outer list, where each binding is itself a  
list of the form `(VAR EXPR)`. The previous code was missing the  
outer parentheses around the binding pairs, which is invalid  
syntax and would cause a runtime error.  

Incorrect (before):  

```elisp

(when-let* (cand (car (member str ...)))
  ...)

(if-let* (info (get-text-property (point) :consult-gh))
  ...)

```

Correct (after):  

```elisp

(when-let* ((cand (car (member str ...))))
  ...)

(if-let* ((info (get-text-property (point) :consult-gh)))
  ...)

```

The fix was applied to two locations in `consult-gh.el` and  
their corresponding counterparts in `consult-gh.org`:  

1.  In the `exit-fun` lambda used for completing "@.\*" mentions  
    of users in comments and posts, where `cand` was being bound  
    via `when-let*` without proper list wrapping.

2.  In the reply-target branch of the comment function, where  
    `info` was being bound via `if-let*` without proper list  
    wrapping.

These corrections ensure the macros expand properly and that  
variable binding behaves as intended at runtime.