### PR TITLE
Bump version from 3.0 to 3.1 across all consult-gh package files

### DIFF
--- a/consult-gh-embark.el
+++ b/consult-gh-embark.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "3.0") (embark-consult "1.1") (which-key "3.6.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "3.1") (embark-consult "1.1") (which-key "3.6.0"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh-forge.el
+++ b/consult-gh-forge.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "3.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "3.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh-nerd-icons.el
+++ b/consult-gh-nerd-icons.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (nerd-icons "0.1.0") (consult-gh "3.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (nerd-icons "0.1.0") (consult-gh "3.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 

--- a/consult-gh-transient.el
+++ b/consult-gh-transient.el
@@ -5,7 +5,7 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
+;; Version: 3.1
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 

--- a/consult-gh-with-pr-review.el
+++ b/consult-gh-with-pr-review.el
@@ -5,8 +5,8 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "3.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "3.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 

--- a/consult-gh.el
+++ b/consult-gh.el
@@ -5,7 +5,7 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
+;; Version: 3.1
 ;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0") (yaml "1.2.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh

--- a/consult-gh.org
+++ b/consult-gh.org
@@ -12,7 +12,7 @@
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
+;; Version: 3.1
 ;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0") (yaml "1.2.0"))
 ;; Keywords: convenience, matching, tools, vc
 ;; Homepage: https://github.com/armindarvish/consult-gh
@@ -26536,8 +26536,8 @@ This section includes additional useful embark actions as well as keymaps.
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "3.0") (embark-consult "1.1") (which-key "3.6.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "3.1") (embark-consult "1.1") (which-key "3.6.0"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 
@@ -28531,8 +28531,8 @@ uses `compose-mail' for composing an email."
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "3.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (forge "0.3.3") (consult-gh "3.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 
@@ -28965,8 +28965,8 @@ default behavior of `ghub--host' to allow using
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "3.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (consult "2.0") (pr-review "0.1") (consult-gh "3.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 
@@ -29200,8 +29200,8 @@ default behavior of `ghub--host' to allow using
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
-;; Package-Requires: ((emacs "29.4") (nerd-icons "0.1.0") (consult-gh "3.0"))
+;; Version: 3.1
+;; Package-Requires: ((emacs "29.4") (nerd-icons "0.1.0") (consult-gh "3.1"))
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, completion
 
@@ -29500,7 +29500,7 @@ and defaults to `consult-gh-nerd-icons-faces'"
 ;; Author: Armin Darvish
 ;; Maintainer: Armin Darvish
 ;; Created: 2023
-;; Version: 3.0
+;; Version: 3.1
 ;; Homepage: https://github.com/armindarvish/consult-gh
 ;; Keywords: matching, git, repositories, forges, completion
 


### PR DESCRIPTION
# Description

This pull request updates the version number from `3.0` to `3.1` across all  
files in the `consult-gh` package ecosystem. The changes are purely  
version-related metadata updates, ensuring consistency across the main package  
and all its extension modules.  


## Files Modified

The following files have been updated:  

1.  **`consult-gh.el`** — Core package version bumped from `3.0` to `3.1`.
2.  **`consult-gh-embark.el`** — Version bumped from `3.0` to `3.1`, and the  
    `consult-gh` dependency updated from `3.0` to `3.1`.
3.  **`consult-gh-forge.el`** — Version bumped from `3.0` to `3.1`, and the  
    `consult-gh` dependency updated from `3.0` to `3.1`.
4.  **`consult-gh-nerd-icons.el`** — Version bumped from `3.0` to `3.1`, and  
    the `consult-gh` dependency updated from `3.0` to `3.1`.
5.  **`consult-gh-transient.el`** — Version bumped from `3.0` to `3.1`.
6.  **`consult-gh-with-pr-review.el`** — Version bumped from `3.0` to `3.1`,  
    and the `consult-gh` dependency updated from `3.0` to `3.1`.
7.  **`consult-gh.org`** — The literate programming source file updated to  
    reflect all the above version changes across all embedded package headers.


## Nature of Changes

Each file contains a standard Emacs Lisp package header. The relevant fields  
updated are:  

-   **`Version:`** — Incremented from `3.0` to `3.1`.
-   **`Package-Requires:`** — For extension packages that depend on `consult-gh`  
    itself, the minimum required version of `consult-gh` has been updated from  
    `3.0` to `3.1`.


### Example of changes in extension packages:

Before:  

```elisp
;; Version: 3.0
;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "3.0") (embark-consult "1.1") (which-key "3.6.0"))
```

After:  

```elisp
;; Version: 3.1
;; Package-Requires: ((emacs "29.4") (consult "2.0") (consult-gh "3.1") (embark-consult "1.1") (which-key "3.6.0"))
```


### Example of changes in the core package:

Before:  

```elisp
;; Version: 3.0
;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0") (yaml "1.2.0"))
```

After:  

```elisp
;; Version: 3.1
;; Package-Requires: ((emacs "29.4") (consult "2.0") (markdown-mode "2.6") (ox-gfm "1.0") (yaml "1.2.0"))
```


## Why This Matters

Keeping version numbers consistent across all package files and their  
dependency declarations is critical for:  

-   **Package manager compatibility** — Tools like MELPA and `package.el` rely  
    on accurate version metadata to resolve dependencies correctly.
-   **Dependency resolution** — Extension packages declare a minimum version of  
    `consult-gh` they require. Updating these ensures users are not allowed to  
    install an extension with an incompatible older version of the core package.
-   **Release tracking** — Consistent versioning makes it easier to track which  
    features and fixes belong to which release.


## Notes

-   No functional code changes are included in this PR.
-   The `consult-gh.org` file, which serves as the literate programming source  
    for the package, has also been updated to stay in sync with the generated  
    `.el` files.
-   All changes are mechanical and low-risk.


# Commit Messages


## (ec2a9d7)  Bump version to 3.1 across all packages

Update version numbers from 3.0 to 3.1 in all package files  
and their corresponding documentation/org sources. This  
affects the following files:  

-   consult-gh.el
-   consult-gh-embark.el
-   consult-gh-forge.el
-   consult-gh-nerd-icons.el
-   consult-gh-transient.el
-   consult-gh-with-pr-review.el
-   consult-gh.org (all embedded package headers)

The Package-Requires declarations in dependent packages have  
also been updated to reflect the new minimum required version  
of consult-gh:  

Before:  
  (consult-gh "3.0")  

After:  
  (consult-gh "3.1")  

This ensures that packages depending on consult-gh  
(consult-gh-embark, consult-gh-forge, consult-gh-nerd-icons,  
and consult-gh-with-pr-review) will correctly require the  
updated version, preventing compatibility issues with older  
releases.  

No functional changes are introduced in this commit; it is  
purely a version bump to prepare for the 3.1 release.